### PR TITLE
feat(deps): implement tiered dependency management strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,60 +1,113 @@
-# Dependabot configuration for ButterGolf monorepo
-# Automatically checks for dependency updates across all packages
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# =============================================================================
+# Dependabot Configuration for ButterGolf Monorepo
+# =============================================================================
+#
+# STRATEGY: Aligns with pnpm-workspace.yaml tiered versioning
+#
+# TIER 1 (IGNORED): Framework-critical packages - manual upgrades only
+#   - React, React Native, Expo, Tamagui, Next.js, Solito
+#   - These are pinned to exact versions and should NEVER be auto-upgraded
+#
+# TIER 2 (GROUPED): Patch-safe packages - auto PRs allowed
+#   - Prisma, Clerk, TypeScript types
+#   - Updates are grouped by concern for easier review
+#
+# TIER 3 (AUTO): Utility packages - standard auto-update
+#   - General utilities with stable APIs
+# =============================================================================
 
 version: 2
 updates:
-  # Root workspace dependencies
+  # ===========================================================================
+  # Root Workspace
+  # ===========================================================================
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "automerge-safe"
+    # TIER 1: Never auto-upgrade these (pinned in catalog)
+    ignore:
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
     groups:
-      react:
-        patterns:
-          - "react"
-          - "react-dom"
       dev-dependencies:
         patterns:
           - "prettier"
           - "turbo"
-          - "typescript"
+          - "tsx"
 
-  # Web app (Next.js)
+  # ===========================================================================
+  # Web App (Next.js)
+  # ===========================================================================
   - package-ecosystem: "npm"
     directory: "/apps/web"
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "web"
+    # TIER 1: Pinned packages - manual upgrades only
+    ignore:
+      - dependency-name: "next"
+      - dependency-name: "@next/*"
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
+      - dependency-name: "tamagui"
+      - dependency-name: "@tamagui/*"
+    # TIER 2: Grouped for review
     groups:
-      nextjs:
-        patterns:
-          - "next"
-          - "@next/*"
       clerk:
         patterns:
           - "@clerk/*"
           - "svix"
+      types:
+        patterns:
+          - "@types/*"
 
-  # Mobile app (Expo)
+  # ===========================================================================
+  # Mobile App (Expo)
+  # ===========================================================================
   - package-ecosystem: "npm"
     directory: "/apps/mobile"
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "mobile"
+    # TIER 1: Expo ecosystem - requires coordinated upgrades
+    # See: pnpm run deps:upgrade -- --expo
+    ignore:
+      - dependency-name: "expo"
+      - dependency-name: "expo-*"
+      - dependency-name: "react-native"
+      - dependency-name: "react-native-*"
+      - dependency-name: "@react-native/*"
+      - dependency-name: "react"
+      - dependency-name: "tamagui"
+      - dependency-name: "@tamagui/*"
+    # TIER 2: Safe to update
     groups:
-      expo:
-        patterns:
-          - "expo"
-          - "expo-*"
-      react-native:
-        patterns:
-          - "react-native"
-          - "react-native-*"
       clerk:
         patterns:
           - "@clerk/*"
@@ -62,56 +115,106 @@ updates:
         patterns:
           - "@react-navigation/*"
 
-  # UI package
+  # ===========================================================================
+  # UI Package
+  # ===========================================================================
   - package-ecosystem: "npm"
     directory: "/packages/ui"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
-    groups:
-      tamagui:
-        patterns:
-          - "tamagui"
-          - "@tamagui/*"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "ui"
+    # TIER 1: Tamagui - all packages must update together
+    ignore:
+      - dependency-name: "tamagui"
+      - dependency-name: "@tamagui/*"
+      - dependency-name: "react"
+      - dependency-name: "react-native"
 
-  # Database package (Prisma)
+  # ===========================================================================
+  # Database Package (Prisma)
+  # ===========================================================================
   - package-ecosystem: "npm"
     directory: "/packages/db"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "database"
+    # Prisma is TIER 2 - patch updates OK
     groups:
       prisma:
         patterns:
           - "prisma"
           - "@prisma/*"
 
-  # App package (shared features)
+  # ===========================================================================
+  # App Package (Shared Features)
+  # ===========================================================================
   - package-ecosystem: "npm"
     directory: "/packages/app"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    # TIER 1: Cross-platform packages
+    ignore:
+      - dependency-name: "solito"
+      - dependency-name: "tamagui"
+      - dependency-name: "@tamagui/*"
+      - dependency-name: "react"
+      - dependency-name: "react-native"
+      - dependency-name: "react-native-web"
 
-  # Config package
+  # ===========================================================================
+  # Config Package
+  # ===========================================================================
   - package-ecosystem: "npm"
     directory: "/packages/config"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
-    groups:
-      tamagui:
-        patterns:
-          - "tamagui"
-          - "@tamagui/*"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    # TIER 1: Tamagui config
+    ignore:
+      - dependency-name: "tamagui"
+      - dependency-name: "@tamagui/*"
 
-  # GitHub Actions workflows
+  # ===========================================================================
+  # GitHub Actions
+  # ===========================================================================
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,30 @@
+# =============================================================================
+# pnpm Configuration for Deterministic Builds
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Dependency Resolution Strategy
+# -----------------------------------------------------------------------------
+# Use "lowest-direct" to prevent automatic upgrades within semver ranges
+# This ensures `pnpm install` only upgrades when explicitly requested
+resolution-mode=lowest-direct
+
+# Prefer workspace packages over registry versions
+prefer-workspace-packages=true
+
+# -----------------------------------------------------------------------------
+# Version Locking & Consistency
+# -----------------------------------------------------------------------------
+# Save exact versions when adding new dependencies via `pnpm add`
+save-exact=true
+
+# Prevent lockfile updates during install (local development)
+# Set to false to allow lockfile generation; CI enforces --frozen-lockfile
+prefer-frozen-lockfile=true
+
+# -----------------------------------------------------------------------------
+# Hoisting Configuration (Required for React Native + Tamagui)
+# -----------------------------------------------------------------------------
 # Hoist dependencies to root to avoid duplication
 shamefully-hoist=true
 
@@ -5,6 +32,17 @@ shamefully-hoist=true
 dedupe-peer-dependents=true
 strict-peer-dependencies=false
 
-# Public hoisting patterns
+# Public hoisting patterns - required for Metro bundler and Tamagui
 public-hoist-pattern[]=*react*
 public-hoist-pattern[]=*@tamagui*
+public-hoist-pattern[]=expo-*
+public-hoist-pattern[]=@expo/*
+
+# -----------------------------------------------------------------------------
+# Performance & Caching
+# -----------------------------------------------------------------------------
+# Side effects cache for faster rebuilds
+side-effects-cache=true
+
+# Enable content-addressable storage linking
+use-store-server=false

--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "check-types": "turbo run check-types",
     "clean": "turbo run clean && rm -rf node_modules",
-    "clean-install": "pnpm clean && pnpm install"
+    "clean-install": "pnpm clean && pnpm install",
+    "deps:check": "bash scripts/deps-check.sh",
+    "deps:upgrade": "bash scripts/deps-upgrade.sh",
+    "deps:outdated": "pnpm outdated --recursive",
+    "preinstall": "npx only-allow pnpm"
   },
   "devDependencies": {
     "@tamagui/cli": "^1.135.7",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,59 @@
+# =============================================================================
+# pnpm Workspace Configuration
+# =============================================================================
+#
+# DEPENDENCY VERSIONING STRATEGY
+# ------------------------------
+# This monorepo uses a tiered versioning strategy via pnpm catalogs:
+#
+# TIER 1 - PINNED (exact versions, no prefix)
+#   - Framework-critical packages where ANY update can break builds
+#   - Examples: React, React Native, Expo, Tamagui, Next.js
+#   - Updated: Only via explicit upgrade workflow (see scripts/upgrade-deps.sh)
+#
+# TIER 2 - MINOR-SAFE (~ tilde prefix)
+#   - Packages where patch updates are safe, but minor versions may have breaking changes
+#   - Examples: Prisma, Clerk, Stripe SDKs
+#   - Updated: Automatically via Dependabot within tilde range
+#
+# TIER 3 - FLEXIBLE (^ caret prefix)
+#   - Utility packages with stable APIs
+#   - Examples: lodash, date-fns, utility types
+#   - Updated: Automatically via Dependabot
+#
+# HOW TO ADD DEPENDENCIES
+# -----------------------
+# 1. Add version to catalog below under appropriate tier
+# 2. Reference in package.json as: "package-name": "catalog:"
+# 3. Run: pnpm install
+#
+# HOW TO UPGRADE DEPENDENCIES
+# ---------------------------
+# Safe upgrade: pnpm run deps:check && pnpm run deps:upgrade
+# Single package: pnpm update <package> --latest
+# =============================================================================
+
 packages:
   - "apps/*"
   - "packages/*"
 
 catalog:
-  # Tamagui UI Framework - all pinned to 1.135.7 for consistency
+  # ===========================================================================
+  # TIER 1: PINNED - Framework Critical (exact versions)
+  # ===========================================================================
+  # WARNING: Do not change these without running full test suite
+  # These packages have tight coupling and version-specific APIs
+
+  # React Ecosystem - Must match across all packages
+  "react": "19.1.0"
+  "react-dom": "19.1.0"
+  "react-native": "0.81.5"
+  "react-native-web": "0.21.2"
+  "react-native-safe-area-context": "5.6.2"
+  "react-native-screens": "4.18.0"
+
+  # Tamagui UI Framework - All packages must use same version
+  # See: https://tamagui.dev/docs/intro/releases for changelog
   "tamagui": "1.135.7"
   "@tamagui/animations-css": "1.135.7"
   "@tamagui/animations-react-native": "1.135.7"
@@ -21,40 +71,46 @@ catalog:
   "@tamagui/themes": "1.135.7"
   "@tamagui/toast": "1.135.7"
 
-  # React Ecosystem
-  "react": "19.1.0"
-  "react-dom": "19.1.0"
-  "react-native": "0.81.5"
-  "react-native-web": "0.21.2"
-  "react-native-safe-area-context": "5.6.2"
-  "react-native-screens": "4.18.0"
-
-  # Cross-Platform Navigation
-  "solito": "5.0.0"
-
-  # Next.js
-  "next": "16.0.1"
-
-  # TypeScript
-  "typescript": "5.9.3"
-  "@types/react": "19.2.6"
-  "@types/react-dom": "19.2.3"
-  "@types/node": "20.19.24"
-
-  # ESLint
-  "eslint": "9.39.1"
-  "eslint-config-expo": "10.0.0"
-
-  # Prisma (Database ORM)
-  "prisma": "6.19.0"
-  "@prisma/client": "6.19.0"
-
-  # Clerk (Authentication)
-  "@clerk/nextjs": "6.34.1"
-  "@clerk/clerk-expo": "2.17.3"
-
-  # Expo
+  # Expo - Tied to specific React Native version
+  # Expo 54 requires RN 0.81.x - DO NOT upgrade independently
   "expo": "54.0.23"
   "expo-auth-session": "7.0.8"
   "expo-secure-store": "15.0.7"
   "expo-status-bar": "3.0.8"
+
+  # Next.js - Major framework, test thoroughly before upgrading
+  "next": "16.0.1"
+
+  # Cross-Platform Navigation
+  "solito": "5.0.0"
+
+  # TypeScript - Compiler version affects type checking
+  "typescript": "5.9.3"
+
+  # ===========================================================================
+  # TIER 2: MINOR-SAFE - Stable within minor version (~)
+  # ===========================================================================
+  # These packages follow semver well; patch updates are safe
+
+  # Type Definitions - Should match runtime versions
+  "@types/react": "~19.2.6"
+  "@types/react-dom": "~19.2.3"
+  "@types/node": "~20.19.24"
+
+  # Database ORM - Schema-sensitive, test migrations
+  "prisma": "~6.19.0"
+  "@prisma/client": "~6.19.0"
+
+  # Authentication - Test auth flows after updates
+  "@clerk/nextjs": "~6.34.1"
+  "@clerk/clerk-expo": "~2.17.3"
+
+  # Linting - Minor versions may add new rules
+  "eslint": "~9.39.1"
+  "eslint-config-expo": "~10.0.0"
+
+  # ===========================================================================
+  # TIER 3: FLEXIBLE - Utility packages (^)
+  # ===========================================================================
+  # These packages have stable APIs; minor updates are generally safe
+  # Add common utility packages here as needed

--- a/scripts/deps-check.sh
+++ b/scripts/deps-check.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# =============================================================================
+# Dependency Validation Script
+# =============================================================================
+# Validates that the lockfile is consistent and no unexpected upgrades occur.
+# Run this before committing changes to ensure CI will pass.
+#
+# Usage: pnpm run deps:check
+# =============================================================================
+
+set -e
+
+echo "🔍 Checking dependency consistency..."
+echo ""
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Track if any checks fail
+FAILED=0
+
+# -----------------------------------------------------------------------------
+# 1. Verify lockfile is up to date (no changes needed)
+# -----------------------------------------------------------------------------
+echo "📦 Verifying lockfile consistency..."
+if pnpm install --frozen-lockfile --ignore-scripts > /dev/null 2>&1; then
+    echo -e "${GREEN}✓${NC} Lockfile is consistent"
+else
+    echo -e "${RED}✗${NC} Lockfile is out of sync. Run 'pnpm install' and commit the lockfile."
+    FAILED=1
+fi
+
+# -----------------------------------------------------------------------------
+# 2. Check for version consistency across workspaces
+# -----------------------------------------------------------------------------
+echo ""
+echo "🔄 Checking version consistency across workspaces..."
+if npx check-dependency-version-consistency . 2>/dev/null; then
+    echo -e "${GREEN}✓${NC} All workspace dependencies are consistent"
+else
+    echo -e "${YELLOW}⚠${NC} Some dependency versions may be inconsistent (check output above)"
+fi
+
+# -----------------------------------------------------------------------------
+# 3. Check for duplicate packages in node_modules
+# -----------------------------------------------------------------------------
+echo ""
+echo "📋 Checking for duplicate packages..."
+REACT_COUNT=$(find node_modules -name "package.json" -path "*/react/package.json" 2>/dev/null | wc -l)
+if [ "$REACT_COUNT" -gt 1 ]; then
+    echo -e "${RED}✗${NC} Multiple React versions detected ($REACT_COUNT instances)"
+    echo "   Run 'pnpm dedupe' to resolve"
+    FAILED=1
+else
+    echo -e "${GREEN}✓${NC} No duplicate React versions"
+fi
+
+# -----------------------------------------------------------------------------
+# 4. Verify critical version constraints
+# -----------------------------------------------------------------------------
+echo ""
+echo "🔐 Verifying critical version constraints..."
+
+# Check React version
+REACT_VERSION=$(node -p "require('./node_modules/react/package.json').version" 2>/dev/null || echo "not found")
+if [ "$REACT_VERSION" = "19.1.0" ]; then
+    echo -e "${GREEN}✓${NC} React version: $REACT_VERSION"
+else
+    echo -e "${RED}✗${NC} React version mismatch: expected 19.1.0, got $REACT_VERSION"
+    FAILED=1
+fi
+
+# Check React Native version (if installed - may not be in web-only CI)
+if [ -d "node_modules/react-native" ]; then
+    RN_VERSION=$(node -p "require('./node_modules/react-native/package.json').version" 2>/dev/null || echo "not found")
+    if [[ "$RN_VERSION" == 0.81.* ]]; then
+        echo -e "${GREEN}✓${NC} React Native version: $RN_VERSION (0.81.x required for Expo 54)"
+    else
+        echo -e "${RED}✗${NC} React Native version mismatch: expected 0.81.x, got $RN_VERSION"
+        FAILED=1
+    fi
+fi
+
+# Check Tamagui version
+if [ -d "node_modules/tamagui" ]; then
+    TAMAGUI_VERSION=$(node -p "require('./node_modules/tamagui/package.json').version" 2>/dev/null || echo "not found")
+    if [ "$TAMAGUI_VERSION" = "1.135.7" ]; then
+        echo -e "${GREEN}✓${NC} Tamagui version: $TAMAGUI_VERSION"
+    else
+        echo -e "${RED}✗${NC} Tamagui version mismatch: expected 1.135.7, got $TAMAGUI_VERSION"
+        FAILED=1
+    fi
+fi
+
+# -----------------------------------------------------------------------------
+# 5. Summary
+# -----------------------------------------------------------------------------
+echo ""
+if [ $FAILED -eq 0 ]; then
+    echo -e "${GREEN}═══════════════════════════════════════════════════════════════${NC}"
+    echo -e "${GREEN}  All dependency checks passed!${NC}"
+    echo -e "${GREEN}═══════════════════════════════════════════════════════════════${NC}"
+    exit 0
+else
+    echo -e "${RED}═══════════════════════════════════════════════════════════════${NC}"
+    echo -e "${RED}  Some dependency checks failed. Please fix the issues above.${NC}"
+    echo -e "${RED}═══════════════════════════════════════════════════════════════${NC}"
+    exit 1
+fi

--- a/scripts/deps-upgrade.sh
+++ b/scripts/deps-upgrade.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# =============================================================================
+# Safe Dependency Upgrade Script
+# =============================================================================
+# Provides a controlled workflow for upgrading dependencies safely.
+#
+# Usage:
+#   pnpm run deps:upgrade              # Interactive mode
+#   pnpm run deps:upgrade -- --tier2   # Upgrade tier 2 (patch) dependencies
+#   pnpm run deps:upgrade -- --all     # Check all available updates
+#   pnpm run deps:upgrade -- --expo    # Expo upgrade workflow
+# =============================================================================
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+echo ""
+echo -e "${CYAN}═══════════════════════════════════════════════════════════════${NC}"
+echo -e "${CYAN}  ButterGolf Dependency Upgrade Tool${NC}"
+echo -e "${CYAN}═══════════════════════════════════════════════════════════════${NC}"
+echo ""
+
+# -----------------------------------------------------------------------------
+# Parse arguments
+# -----------------------------------------------------------------------------
+MODE="interactive"
+for arg in "$@"; do
+    case $arg in
+        --tier2)
+            MODE="tier2"
+            ;;
+        --all)
+            MODE="all"
+            ;;
+        --expo)
+            MODE="expo"
+            ;;
+        --help|-h)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --tier2    Upgrade tier 2 (patch-safe) dependencies only"
+            echo "  --all      Show all available updates"
+            echo "  --expo     Run Expo-specific upgrade workflow"
+            echo "  --help     Show this help message"
+            echo ""
+            exit 0
+            ;;
+    esac
+done
+
+# -----------------------------------------------------------------------------
+# Mode: Show all available updates
+# -----------------------------------------------------------------------------
+if [ "$MODE" = "all" ]; then
+    echo -e "${BLUE}Checking for available updates...${NC}"
+    echo ""
+
+    echo -e "${YELLOW}📦 Outdated packages:${NC}"
+    pnpm outdated --recursive 2>/dev/null || echo "All packages are up to date!"
+
+    echo ""
+    echo -e "${YELLOW}To upgrade a specific package:${NC}"
+    echo "  pnpm update <package-name> --latest"
+    echo ""
+    echo -e "${YELLOW}To upgrade all packages in catalog, edit:${NC}"
+    echo "  pnpm-workspace.yaml"
+    echo ""
+    exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Mode: Upgrade tier 2 (patch-safe) dependencies
+# -----------------------------------------------------------------------------
+if [ "$MODE" = "tier2" ]; then
+    echo -e "${BLUE}Upgrading tier 2 (patch-safe) dependencies...${NC}"
+    echo ""
+
+    # Update within tilde ranges (patches only)
+    pnpm update --recursive
+
+    # Regenerate lockfile
+    pnpm install
+
+    echo ""
+    echo -e "${GREEN}✓${NC} Tier 2 dependencies updated"
+    echo ""
+    echo -e "${YELLOW}Next steps:${NC}"
+    echo "  1. Run: pnpm run deps:check"
+    echo "  2. Run: pnpm run check-types"
+    echo "  3. Run: pnpm run build"
+    echo "  4. Test your application"
+    echo "  5. Commit changes: git add pnpm-lock.yaml && git commit -m 'chore(deps): update patch dependencies'"
+    echo ""
+    exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Mode: Expo upgrade workflow
+# -----------------------------------------------------------------------------
+if [ "$MODE" = "expo" ]; then
+    echo -e "${RED}⚠️  EXPO UPGRADE WORKFLOW${NC}"
+    echo ""
+    echo "Expo upgrades are complex because they require coordinated updates of:"
+    echo "  - expo"
+    echo "  - react-native (specific version per Expo SDK)"
+    echo "  - expo-* packages"
+    echo "  - @react-native-* packages"
+    echo ""
+    echo -e "${YELLOW}Steps to upgrade Expo:${NC}"
+    echo ""
+    echo "1. Check compatibility matrix:"
+    echo "   https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/"
+    echo ""
+    echo "2. Run Expo's upgrade tool (from apps/mobile):"
+    echo "   cd apps/mobile && npx expo install expo@latest"
+    echo ""
+    echo "3. Update React Native to compatible version in pnpm-workspace.yaml:"
+    echo "   - Expo 54 → React Native 0.81.x"
+    echo "   - Expo 55 → React Native 0.82.x (check docs)"
+    echo ""
+    echo "4. Update all expo-* packages:"
+    echo "   cd apps/mobile && npx expo install --fix"
+    echo ""
+    echo "5. Update pnpm-workspace.yaml catalog with new versions"
+    echo ""
+    echo "6. Run full validation:"
+    echo "   pnpm install && pnpm run deps:check && pnpm run build"
+    echo ""
+    exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Mode: Interactive
+# -----------------------------------------------------------------------------
+echo "Select an upgrade strategy:"
+echo ""
+echo -e "  ${GREEN}1)${NC} Check available updates (safe, no changes)"
+echo -e "  ${GREEN}2)${NC} Upgrade tier 2 dependencies (patches only)"
+echo -e "  ${GREEN}3)${NC} Expo SDK upgrade workflow"
+echo -e "  ${GREEN}4)${NC} Exit"
+echo ""
+read -p "Enter choice [1-4]: " choice
+
+case $choice in
+    1)
+        exec "$0" --all
+        ;;
+    2)
+        exec "$0" --tier2
+        ;;
+    3)
+        exec "$0" --expo
+        ;;
+    4|*)
+        echo "Exiting."
+        exit 0
+        ;;
+esac

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm turbo run build --filter=web",
+  "outputDirectory": "apps/web/.next",
+  "env": {
+    "TURBO_REMOTE_ONLY": "true"
+  }
 }


### PR DESCRIPTION
This commit introduces a robust dependency management approach that:

1. **Prevents unexpected upgrades** via pnpm configuration:
   - `resolution-mode=lowest-direct` prevents auto-upgrades within semver ranges
   - `save-exact=true` pins new dependencies by default
   - `prefer-frozen-lockfile=true` warns when lockfile changes locally

2. **Tiered versioning strategy** in pnpm catalog:
   - TIER 1 (PINNED): React, RN, Expo, Tamagui, Next.js - exact versions
   - TIER 2 (MINOR-SAFE): Prisma, Clerk, types - tilde ranges (~)
   - TIER 3 (FLEXIBLE): Utilities - caret ranges (^)

3. **CI consistency**:
   - Vercel now uses `--frozen-lockfile` for deterministic builds
   - Dependabot ignores TIER 1 packages (manual upgrades only)
   - Added `deps:check` validation script for pre-commit verification

4. **Safe upgrade workflow**:
   - `pnpm run deps:check` - validates lockfile consistency
   - `pnpm run deps:upgrade` - guided upgrade workflow
   - `pnpm run deps:outdated` - check available updates

This resolves the issue where `pnpm install` would automatically upgrade
packages like Tamagui 1.135.7→1.138.1 or React Native 0.81.5→0.82.1,
breaking Expo 54 compatibility.