### PR TITLE
Enable Tamagui animations and add PageContainer

### DIFF
--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { Column, Row, Heading, Text, Card } from "@buttergolf/ui";
+import { PageContainer, Column, Row, Heading, Text, Card } from "@buttergolf/ui";
 
 export default function SettingsPage() {
     const router = useRouter();
@@ -28,7 +28,7 @@ export default function SettingsPage() {
     ];
 
     return (
-        <Column
+        <PageContainer
             backgroundColor="$background"
             minHeight="100vh"
             alignItems="center"
@@ -87,6 +87,6 @@ export default function SettingsPage() {
                     </Column>
                 </Column>
             </Column>
-        </Column>
+        </PageContainer>
     );
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -8,7 +8,6 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@tamagui/animations-css": "catalog:",
     "@tamagui/animations-react-native": "catalog:",
     "@tamagui/config": "catalog:",
     "@tamagui/font-inter": "catalog:",

--- a/packages/ui/src/components/PageContainer.tsx
+++ b/packages/ui/src/components/PageContainer.tsx
@@ -1,0 +1,45 @@
+/**
+ * PageContainer Component
+ *
+ * A layout component that provides a smooth fade-in and slide-up animation
+ * when content is mounted. Uses Tamagui's animation system for cross-platform
+ * compatibility (web and mobile).
+ *
+ * @example
+ * ```tsx
+ * export default function MyPage() {
+ *   return (
+ *     <PageContainer>
+ *       <Heading>Welcome</Heading>
+ *       <Text>Page content fades in smoothly</Text>
+ *     </PageContainer>
+ *   )
+ * }
+ * ```
+ */
+
+'use client'
+
+import { YStack, type YStackProps } from 'tamagui'
+
+export type PageContainerProps = YStackProps
+
+/**
+ * PageContainer - Animated page wrapper with fade-in effect
+ *
+ * Automatically fades in and slides up content on mount using the 'medium'
+ * animation preset from the Tamagui config.
+ *
+ * Props: Accepts all YStack props (flex, padding, gap, etc.)
+ */
+export function PageContainer(props: PageContainerProps) {
+  return (
+    <YStack
+      animation="medium"
+      enterStyle={{ opacity: 0, y: 20 }}
+      opacity={1}
+      y={0}
+      {...props}
+    />
+  )
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -21,6 +21,8 @@ export type { TextProps, HeadingProps, LabelProps } from './components/Text'
 // Layout Components (semantic components with variants)
 export { Row, Column, Container, Spacer, XStack, YStack, View } from './components/Layout'
 export type { RowProps, ColumnProps, ContainerProps, SpacerProps, XStackProps, YStackProps, ViewProps } from './components/Layout'
+export { PageContainer } from './components/PageContainer'
+export type { PageContainerProps } from './components/PageContainer'
 
 // Card Components
 export { Card, CardHeader, CardBody, CardFooter } from './components/Card'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,9 +476,6 @@ importers:
 
   packages/config:
     dependencies:
-      '@tamagui/animations-css':
-        specifier: 'catalog:'
-        version: 1.135.7(react-dom@19.1.0(react@19.1.0))(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.6)(react@19.1.0))(react@19.1.0)
       '@tamagui/animations-react-native':
         specifier: 'catalog:'
         version: 1.135.7(react-dom@19.1.0(react@19.1.0))(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.6)(react@19.1.0))(react@19.1.0)
@@ -15277,7 +15274,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.1
       eslint: 9.39.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.0(jiti@2.6.1))
@@ -15304,7 +15301,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -15334,14 +15331,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -15376,7 +15373,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
Setup:
- Animations already configured using @tamagui/animations-react-native in tamagui.config.ts
- Removed unused @tamagui/animations-css dependency from config package

New Component:
- Created PageContainer component in packages/ui/src/components/PageContainer.tsx
- Provides smooth fade-in and slide-up animation on mount
- Uses 'medium' animation preset from Tamagui config
- Cross-platform compatible (web and mobile)
- Accepts all YStack props for flexibility

Integration:
- Exported PageContainer from @buttergolf/ui package
- Applied to settings page as a demonstration
- Page content now fades in smoothly on mount

Technical Details:
- Uses enterStyle={{ opacity: 0, y: 20 }} for initial state
- Animates to opacity={1} and y={0} final state
- Marked with 'use client' for client-side animation
- No changes to existing GSAP setup (preserved for later migration)