### PR TITLE
fix: Sentry source-map upload org slug (rwxt → kyln-digital)

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -213,7 +213,7 @@ module.exports = withSentryConfig(module.exports, {
   // For all available options, see:
   // https://www.npmjs.com/package/@sentry/webpack-plugin#options
 
-  org: "rwxt",
+  org: "kyln-digital",
   project: "buttergolf",
 
   // Only print logs for uploading source maps in CI


### PR DESCRIPTION
`withSentryConfig` in `apps/web/next.config.js` pointed source-map uploads at org `rwxt`, which 404s (it's the *team* slug; the org is `kyln-digital`). Error ingestion was unaffected — the DSN routes by org id — but uploads went nowhere, so production stack traces stayed minified. One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)