### PR TITLE
fix(deps): patch 4 critical Dependabot advisories (Clerk auth bypass, shell-quote, simple-git)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
       "react-native-svg": "15.12.1",
       "react-native-reanimated": "4.1.1",
       "expo-constants": "18.0.13",
-      "simple-git": "^3.36.0",
-      "shell-quote": "^1.8.4"
+      "simple-git": "3.36.0",
+      "shell-quote": "1.9.0"
     },
     "ignoredBuiltDependencies": [
       "@clerk/shared",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,9 @@
       "react-native": "0.81.5",
       "react-native-svg": "15.12.1",
       "react-native-reanimated": "4.1.1",
-      "expo-constants": "18.0.13"
+      "expo-constants": "18.0.13",
+      "simple-git": "^3.36.0",
+      "shell-quote": "^1.8.4"
     },
     "ignoredBuiltDependencies": [
       "@clerk/shared",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     "@clerk/clerk-expo":
-      specifier: 2.19.26
-      version: 2.19.26
+      specifier: 2.19.36
+      version: 2.19.36
     "@clerk/nextjs":
-      specifier: 6.38.1
-      version: 6.38.1
+      specifier: 6.39.3
+      version: 6.39.3
     "@easypost/api":
       specifier: 8.2.0
       version: 8.2.0
@@ -256,6 +256,8 @@ overrides:
   react-native-svg: 15.12.1
   react-native-reanimated: 4.1.1
   expo-constants: 18.0.13
+  simple-git: ^3.36.0
+  shell-quote: ^1.8.4
 
 importers:
   .:
@@ -314,7 +316,7 @@ importers:
         version: link:../../packages/ui
       "@clerk/clerk-expo":
         specifier: "catalog:"
-        version: 2.19.26(576b72f44a86ed6708e304f0fca765fd)
+        version: 2.19.36(576b72f44a86ed6708e304f0fca765fd)
       "@expo-google-fonts/urbanist":
         specifier: ^0.4.2
         version: 0.4.2
@@ -459,7 +461,7 @@ importers:
         version: link:../../packages/ui
       "@clerk/nextjs":
         specifier: "catalog:"
-        version: 6.38.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 6.39.3(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       "@dnd-kit/core":
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -474,7 +476,7 @@ importers:
         version: 8.2.0
       "@sentry/nextjs":
         specifier: "catalog:"
-        version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.104.1(esbuild@0.25.12))
+        version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.104.1(esbuild@0.27.3))
       "@stripe/connect-js":
         specifier: "catalog:"
         version: 3.3.34
@@ -607,7 +609,7 @@ importers:
         version: 4.1.18
       "@tamagui/next-plugin":
         specifier: "catalog:"
-        version: 1.144.3(@babel/core@7.29.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.25.12))
+        version: 1.144.3(@babel/core@7.29.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.27.3))
       "@types/canvas-confetti":
         specifier: "catalog:"
         version: 1.9.0
@@ -1779,17 +1781,17 @@ packages:
         integrity: sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==,
       }
 
-  "@clerk/backend@2.32.0":
+  "@clerk/backend@2.33.5":
     resolution:
       {
-        integrity: sha512-bUCrENRjJzqyk6lsiQQnLs4bsejfD7z2Wmpcd5XN0YXklSvtgYd4ILB8+QLCv+xKVIe5WraA+Iv0ZrKb0fyZUw==,
+        integrity: sha512-YOzUYJfb1d4w+0rKKm+LnnNpkJGQ+NI/g7qmF3mgaSN9X9huteuwCZyufdsI7z2DDkwy/yGRgb9eUWV96t7xLg==,
       }
     engines: { node: ">=18.17.0" }
 
-  "@clerk/clerk-expo@2.19.26":
+  "@clerk/clerk-expo@2.19.36":
     resolution:
       {
-        integrity: sha512-H5sO/rQUksTTLIRWEWTJQQhEkRIAFnJ3oYaNACyKpL+iuTBdamoKGRlF7uJJ7f+WQDWbx42M8s2NG1ajfA7hpA==,
+        integrity: sha512-ZpF0IfH7bkJBQCl8PtnzBfGac6mHBMlEEbOAJ9jWcsAcBdbH33arB8/V/o942Bh61x4/OORd+DyatkXDG3FDsg==,
       }
     engines: { node: ">=18.17.0" }
     peerDependencies:
@@ -1815,37 +1817,37 @@ packages:
       expo-secure-store:
         optional: true
 
-  "@clerk/clerk-js@5.125.0":
+  "@clerk/clerk-js@5.127.0":
     resolution:
       {
-        integrity: sha512-wiGtJckWO/LFJLCFzXNXq9edVRLMprLmrBBGYx2U+LJc1NOfrwfIypasKuPjMkrUUF67oF/79U+XdDIeYFqj7A==,
+        integrity: sha512-4U0wBVtDs5jz126feM8UnGr9nnLpiNCSnbxq0qFErW1E31sW4mmccpc7o4B3QqIbv68PqWjPVQlmebJ/xDn/wg==,
       }
     engines: { node: ">=18.17.0" }
     peerDependencies:
       react: 19.1.0
       react-dom: 19.1.0
 
-  "@clerk/clerk-react@5.61.1":
+  "@clerk/clerk-react@5.61.8":
     resolution:
       {
-        integrity: sha512-FB6Dt6iwNR//UG/Xt61+WJKj6wtxvPtrF4CgO3Vm3GWb6xyFPZUFRrcdE4pZrF1glCVZ1TXEAAvDMFOAM4ybRw==,
+        integrity: sha512-n+k3q3xeyDkIPGTVA1J4Pd0+6MbS9Ia04qNlecOztTHwFfcirO5hy4TpOXrpGnO+GzYBuUMp7pYc3//ybMdEfg==,
       }
     engines: { node: ">=18.17.0" }
     peerDependencies:
       react: 19.1.0
       react-dom: 19.1.0
 
-  "@clerk/localizations@3.37.0":
+  "@clerk/localizations@3.37.7":
     resolution:
       {
-        integrity: sha512-jiv5rFKGgu6n6Ex2VEJ3GyUSAd3YHlyykT/BUKEXCtoWnGMVZFh2RRIhzT177+YagZyrJq//mU6vO9jagMfaEg==,
+        integrity: sha512-mEIPSg0EYveROmza8MlqPH6P+YCzgsQIAnCtbem74ekXG7Y0X/hne+E9T5xPsuf9FHaavNMbECn5SiYXTgUfmA==,
       }
     engines: { node: ">=18.17.0" }
 
-  "@clerk/nextjs@6.38.1":
+  "@clerk/nextjs@6.39.3":
     resolution:
       {
-        integrity: sha512-QPweHCcL2LbFtjO25ymlQjBthk2L2oh1Jjh3+zV2iWOxlf3jmKKHs8kPfHeH6p7ndZKp8SLH45U8zmVZLCteiA==,
+        integrity: sha512-a64lJ1IlV1uA7eEe8DOx+v2bkNOhnTsNlB5THP/xkHvynHqZhc74Yt05sm1vTniWwhJpJspAZ95pCWUX/RVZ2Q==,
       }
     engines: { node: ">=18.17.0" }
     peerDependencies:
@@ -1853,10 +1855,10 @@ packages:
       react: 19.1.0
       react-dom: 19.1.0
 
-  "@clerk/shared@3.47.0":
+  "@clerk/shared@3.47.7":
     resolution:
       {
-        integrity: sha512-EDWFysptTc58X96MGQIZ3LlcMFKLG+rhIF9kf6n+wnyQDWnfuyA8I8ge7GbjfUXMf00c//A/CGSjg7t/oupUpw==,
+        integrity: sha512-9Yv4MJFEaC7BzV0whxa4txQ4SoMu/3j1LBnI85EBykb5CcfXxIKvNX/9sjMUUySHlTOjsj7XZa5i3W5Dx02K/Q==,
       }
     engines: { node: ">=18.17.0" }
     peerDependencies:
@@ -1868,10 +1870,10 @@ packages:
       react-dom:
         optional: true
 
-  "@clerk/types@4.101.18":
+  "@clerk/types@4.101.25":
     resolution:
       {
-        integrity: sha512-huTv4ESnNK5ujCSc0vUNtK2k5xMDOP5C96qOUPB0AZyOWeMYEou5tHDua2NOlgFZAS/M+dJBOffohbiO2mLAhw==,
+        integrity: sha512-gPxm3hlBkP7B9EfKyp3/UDonNOjg7Z0UvqfrMj5u8gA8nyzvC1UFYtSTTmTfgSY82+5Yo38YV0DYu9vNf6t9CQ==,
       }
     engines: { node: ">=18.17.0" }
 
@@ -5638,6 +5640,18 @@ packages:
     engines: { node: ">= 14" }
     peerDependencies:
       webpack: ">=4.40.0"
+
+  "@simple-git/args-pathspec@1.0.3":
+    resolution:
+      {
+        integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==,
+      }
+
+  "@simple-git/argv-parser@1.1.1":
+    resolution:
+      {
+        integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==,
+      }
 
   "@sinclair/typebox@0.27.8":
     resolution:
@@ -12767,12 +12781,12 @@ packages:
         integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==,
       }
 
-  js-cookie@3.0.5:
+  js-cookie@3.0.7:
     resolution:
       {
-        integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==,
+        integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==,
       }
-    engines: { node: ">=14" }
+    engines: { node: ">=20" }
 
   js-tokens@4.0.0:
     resolution:
@@ -16151,10 +16165,10 @@ packages:
       }
     engines: { node: ">=8" }
 
-  shell-quote@1.8.3:
+  shell-quote@1.9.0:
     resolution:
       {
-        integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==,
+        integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==,
       }
     engines: { node: ">= 0.4" }
 
@@ -16199,10 +16213,10 @@ packages:
       }
     engines: { node: ">=14" }
 
-  simple-git@3.31.1:
+  simple-git@3.36.0:
     resolution:
       {
-        integrity: sha512-oiWP4Q9+kO8q9hHqkX35uuHmxiEbZNTrZ5IPxgMGrJwN76pzjm/jabkZO0ItEcqxAincqGAzL3QHSaHt4+knBg==,
+        integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==,
       }
 
   simple-plist@1.3.1:
@@ -17671,6 +17685,7 @@ packages:
       {
         integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==,
       }
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
@@ -19060,22 +19075,22 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  "@clerk/backend@2.32.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)":
+  "@clerk/backend@2.33.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)":
     dependencies:
-      "@clerk/shared": 3.47.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      "@clerk/types": 4.101.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      "@clerk/shared": 3.47.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      "@clerk/types": 4.101.25(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       standardwebhooks: 1.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - react
       - react-dom
 
-  "@clerk/clerk-expo@2.19.26(576b72f44a86ed6708e304f0fca765fd)":
+  "@clerk/clerk-expo@2.19.36(576b72f44a86ed6708e304f0fca765fd)":
     dependencies:
-      "@clerk/clerk-js": 5.125.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bs58@5.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@4.3.5)
-      "@clerk/clerk-react": 5.61.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      "@clerk/shared": 3.47.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      "@clerk/types": 4.101.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      "@clerk/clerk-js": 5.127.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bs58@5.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@4.3.5)
+      "@clerk/clerk-react": 5.61.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      "@clerk/shared": 3.47.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      "@clerk/types": 4.101.25(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       base-64: 1.0.0
       expo-auth-session: 7.0.10(expo@54.0.33(@babel/core@7.29.0)(bufferutil@4.1.0)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(utf-8-validate@5.0.10))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       expo-web-browser: 15.0.10(expo@54.0.33(@babel/core@7.29.0)(bufferutil@4.1.0)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(utf-8-validate@5.0.10))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))
@@ -19100,11 +19115,11 @@ snapshots:
       - utf-8-validate
       - zod
 
-  "@clerk/clerk-js@5.125.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bs58@5.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@4.3.5)":
+  "@clerk/clerk-js@5.127.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bs58@5.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@4.3.5)":
     dependencies:
       "@base-org/account": 2.0.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@4.3.5)
-      "@clerk/localizations": 3.37.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      "@clerk/shared": 3.47.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      "@clerk/localizations": 3.37.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      "@clerk/shared": 3.47.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       "@coinbase/wallet-sdk": 4.3.0
       "@emotion/cache": 11.11.0
       "@emotion/react": 11.11.1(@types/react@19.2.14)(react@19.1.0)
@@ -19145,47 +19160,47 @@ snapshots:
       - utf-8-validate
       - zod
 
-  "@clerk/clerk-react@5.61.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)":
+  "@clerk/clerk-react@5.61.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)":
     dependencies:
-      "@clerk/shared": 3.47.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      "@clerk/shared": 3.47.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       tslib: 2.8.1
 
-  "@clerk/localizations@3.37.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)":
+  "@clerk/localizations@3.37.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)":
     dependencies:
-      "@clerk/types": 4.101.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      "@clerk/types": 4.101.25(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - react
       - react-dom
 
-  "@clerk/nextjs@6.38.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)":
+  "@clerk/nextjs@6.39.3(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)":
     dependencies:
-      "@clerk/backend": 2.32.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      "@clerk/clerk-react": 5.61.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      "@clerk/shared": 3.47.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      "@clerk/types": 4.101.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      "@clerk/backend": 2.33.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      "@clerk/clerk-react": 5.61.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      "@clerk/shared": 3.47.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      "@clerk/types": 4.101.25(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       server-only: 0.0.1
       tslib: 2.8.1
 
-  "@clerk/shared@3.47.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)":
+  "@clerk/shared@3.47.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)":
     dependencies:
       csstype: 3.1.3
       dequal: 2.0.3
       glob-to-regexp: 0.4.1
-      js-cookie: 3.0.5
+      js-cookie: 3.0.7
       std-env: 3.10.0
       swr: 2.3.4(react@19.1.0)
     optionalDependencies:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  "@clerk/types@4.101.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)":
+  "@clerk/types@4.101.25(react-dom@19.1.0(react@19.1.0))(react@19.1.0)":
     dependencies:
-      "@clerk/shared": 3.47.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      "@clerk/shared": 3.47.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -20537,7 +20552,7 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.0
       semver: 7.7.4
-      simple-git: 3.31.1
+      simple-git: 3.36.0
       sirv: 3.0.2
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.15
@@ -21753,7 +21768,7 @@ snapshots:
 
   "@sentry/core@10.39.0": {}
 
-  "@sentry/nextjs@10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.104.1(esbuild@0.25.12))":
+  "@sentry/nextjs@10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.104.1(esbuild@0.27.3))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.39.0
@@ -21765,7 +21780,7 @@ snapshots:
       "@sentry/opentelemetry": 10.39.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)
       "@sentry/react": 10.39.0(react@19.1.0)
       "@sentry/vercel-edge": 10.39.0
-      "@sentry/webpack-plugin": 4.9.1(webpack@5.104.1(esbuild@0.25.12))
+      "@sentry/webpack-plugin": 4.9.1(webpack@5.104.1(esbuild@0.27.3))
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       rollup: 4.58.0
       stacktrace-parser: 0.1.11
@@ -21856,15 +21871,21 @@ snapshots:
       "@opentelemetry/resources": 2.5.1(@opentelemetry/api@1.9.0)
       "@sentry/core": 10.39.0
 
-  "@sentry/webpack-plugin@4.9.1(webpack@5.104.1(esbuild@0.25.12))":
+  "@sentry/webpack-plugin@4.9.1(webpack@5.104.1(esbuild@0.27.3))":
     dependencies:
       "@sentry/bundler-plugin-core": 4.9.1
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.104.1(esbuild@0.25.12)
+      webpack: 5.104.1(esbuild@0.27.3)
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  "@simple-git/args-pathspec@1.0.3": {}
+
+  "@simple-git/argv-parser@1.1.1":
+    dependencies:
+      "@simple-git/args-pathspec": 1.0.3
 
   "@sinclair/typebox@0.27.8": {}
 
@@ -22921,21 +22942,21 @@ snapshots:
       - react-dom
       - react-native
 
-  "@tamagui/next-plugin@1.144.3(@babel/core@7.29.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.25.12))":
+  "@tamagui/next-plugin@1.144.3(@babel/core@7.29.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.27.3))":
     dependencies:
       "@babel/preset-react": 7.28.5(@babel/core@7.29.0)
       "@tamagui/proxy-worm": 1.144.3
       "@tamagui/react-native-svg": 1.144.3(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))
       "@tamagui/static": 1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.104.1(esbuild@0.25.12))
+      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.104.1(esbuild@0.27.3))
       browserslist: 4.28.1
-      css-loader: 6.11.0(webpack@5.104.1(esbuild@0.25.12))
-      esbuild-loader: 4.4.2(webpack@5.104.1(esbuild@0.25.12))
-      file-loader: 6.2.0(webpack@5.104.1(esbuild@0.25.12))
-      html-webpack-plugin: 5.6.5(webpack@5.104.1(esbuild@0.25.12))
+      css-loader: 6.11.0(webpack@5.104.1(esbuild@0.27.3))
+      esbuild-loader: 4.4.2(webpack@5.104.1(esbuild@0.27.3))
+      file-loader: 6.2.0(webpack@5.104.1(esbuild@0.27.3))
+      html-webpack-plugin: 5.6.5(webpack@5.104.1(esbuild@0.27.3))
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      tamagui-loader: 1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.25.12))
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.104.1(esbuild@0.25.12)))(webpack@5.104.1(esbuild@0.25.12))
+      tamagui-loader: 1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.27.3))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.104.1(esbuild@0.27.3)))(webpack@5.104.1(esbuild@0.27.3))
     transitivePeerDependencies:
       - "@babel/core"
       - "@rspack/core"
@@ -24526,12 +24547,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.104.1(esbuild@0.25.12)):
+  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.104.1(esbuild@0.27.3)):
     dependencies:
       "@babel/core": 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.104.1(esbuild@0.25.12)
+      webpack: 5.104.1(esbuild@0.27.3)
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
@@ -25306,7 +25327,7 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
-  css-loader@6.11.0(webpack@5.104.1(esbuild@0.25.12)):
+  css-loader@6.11.0(webpack@5.104.1(esbuild@0.27.3)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -25317,7 +25338,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.4
     optionalDependencies:
-      webpack: 5.104.1(esbuild@0.25.12)
+      webpack: 5.104.1(esbuild@0.27.3)
 
   css-select@4.3.0:
     dependencies:
@@ -25786,12 +25807,12 @@ snapshots:
     dependencies:
       es6-promise: 4.2.8
 
-  esbuild-loader@4.4.2(webpack@5.104.1(esbuild@0.25.12)):
+  esbuild-loader@4.4.2(webpack@5.104.1(esbuild@0.27.3)):
     dependencies:
       esbuild: 0.27.3
       get-tsconfig: 4.13.0
       loader-utils: 2.0.4
-      webpack: 5.104.1(esbuild@0.25.12)
+      webpack: 5.104.1(esbuild@0.27.3)
       webpack-sources: 1.4.3
 
   esbuild-register@3.6.0(esbuild@0.25.12):
@@ -26626,11 +26647,11 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-loader@6.2.0(webpack@5.104.1(esbuild@0.25.12)):
+  file-loader@6.2.0(webpack@5.104.1(esbuild@0.27.3)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.104.1(esbuild@0.25.12)
+      webpack: 5.104.1(esbuild@0.27.3)
 
   file-uri-to-path@1.0.0: {}
 
@@ -27049,7 +27070,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.46.0
 
-  html-webpack-plugin@5.6.5(webpack@5.104.1(esbuild@0.25.12)):
+  html-webpack-plugin@5.6.5(webpack@5.104.1(esbuild@0.27.3)):
     dependencies:
       "@types/html-minifier-terser": 6.1.0
       html-minifier-terser: 6.1.0
@@ -27057,7 +27078,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.0
     optionalDependencies:
-      webpack: 5.104.1(esbuild@0.25.12)
+      webpack: 5.104.1(esbuild@0.27.3)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -27540,7 +27561,7 @@ snapshots:
 
   js-base64@3.7.8: {}
 
-  js-cookie@3.0.5: {}
+  js-cookie@3.0.7: {}
 
   js-tokens@4.0.0: {}
 
@@ -27613,7 +27634,7 @@ snapshots:
   launch-editor@2.13.0:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.9.0
 
   lazystream@1.0.1:
     dependencies:
@@ -29337,7 +29358,7 @@ snapshots:
 
   react-devtools-core@6.1.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
-      shell-quote: 1.8.3
+      shell-quote: 1.9.0
       ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -29998,7 +30019,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.9.0: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -30032,10 +30053,12 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-git@3.31.1:
+  simple-git@3.36.0:
     dependencies:
       "@kwsites/file-exists": 1.1.1
       "@kwsites/promise-deferred": 1.1.1
+      "@simple-git/args-pathspec": 1.0.3
+      "@simple-git/argv-parser": 1.1.1
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -30424,7 +30447,7 @@ snapshots:
 
   tailwindcss@4.1.18: {}
 
-  tamagui-loader@1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.25.12)):
+  tamagui-loader@1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.27.3)):
     dependencies:
       "@tamagui/cli-color": 1.144.3
       "@tamagui/core": 1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
@@ -30432,7 +30455,7 @@ snapshots:
       "@tamagui/static-worker": 1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       "@tamagui/types": 1.144.3
       "@tamagui/web": 1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
-      esbuild-loader: 4.4.2(webpack@5.104.1(esbuild@0.25.12))
+      esbuild-loader: 4.4.2(webpack@5.104.1(esbuild@0.27.3))
       esm-resolve: 1.0.11
       fs-extra: 11.3.3
       loader-utils: 3.3.1
@@ -30530,16 +30553,16 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.16(esbuild@0.25.12)(webpack@5.104.1(esbuild@0.25.12)):
+  terser-webpack-plugin@5.3.16(esbuild@0.27.3)(webpack@5.104.1(esbuild@0.27.3)):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.46.0
-      webpack: 5.104.1(esbuild@0.25.12)
+      webpack: 5.104.1(esbuild@0.27.3)
     optionalDependencies:
-      esbuild: 0.25.12
+      esbuild: 0.27.3
 
   terser@5.46.0:
     dependencies:
@@ -30952,14 +30975,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.104.1(esbuild@0.25.12)))(webpack@5.104.1(esbuild@0.25.12)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.104.1(esbuild@0.27.3)))(webpack@5.104.1(esbuild@0.27.3)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.104.1(esbuild@0.25.12)
+      webpack: 5.104.1(esbuild@0.27.3)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.104.1(esbuild@0.25.12))
+      file-loader: 6.2.0(webpack@5.104.1(esbuild@0.27.3))
 
   url-parse@1.5.10:
     dependencies:
@@ -31218,7 +31241,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.104.1(esbuild@0.25.12):
+  webpack@5.104.1(esbuild@0.27.3):
     dependencies:
       "@types/eslint-scope": 3.7.7
       "@types/estree": 1.0.8
@@ -31242,7 +31265,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.12)(webpack@5.104.1(esbuild@0.25.12))
+      terser-webpack-plugin: 5.3.16(esbuild@0.27.3)(webpack@5.104.1(esbuild@0.27.3))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,8 +256,8 @@ overrides:
   react-native-svg: 15.12.1
   react-native-reanimated: 4.1.1
   expo-constants: 18.0.13
-  simple-git: ^3.36.0
-  shell-quote: ^1.8.4
+  simple-git: 3.36.0
+  shell-quote: 1.9.0
 
 importers:
   .:
@@ -476,7 +476,7 @@ importers:
         version: 8.2.0
       "@sentry/nextjs":
         specifier: "catalog:"
-        version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.104.1(esbuild@0.27.3))
+        version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.104.1(esbuild@0.25.12))
       "@stripe/connect-js":
         specifier: "catalog:"
         version: 3.3.34
@@ -609,7 +609,7 @@ importers:
         version: 4.1.18
       "@tamagui/next-plugin":
         specifier: "catalog:"
-        version: 1.144.3(@babel/core@7.29.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.27.3))
+        version: 1.144.3(@babel/core@7.29.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.25.12))
       "@types/canvas-confetti":
         specifier: "catalog:"
         version: 1.9.0
@@ -21768,7 +21768,7 @@ snapshots:
 
   "@sentry/core@10.39.0": {}
 
-  "@sentry/nextjs@10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.104.1(esbuild@0.27.3))":
+  "@sentry/nextjs@10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.104.1(esbuild@0.25.12))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.39.0
@@ -21780,7 +21780,7 @@ snapshots:
       "@sentry/opentelemetry": 10.39.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)
       "@sentry/react": 10.39.0(react@19.1.0)
       "@sentry/vercel-edge": 10.39.0
-      "@sentry/webpack-plugin": 4.9.1(webpack@5.104.1(esbuild@0.27.3))
+      "@sentry/webpack-plugin": 4.9.1(webpack@5.104.1(esbuild@0.25.12))
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       rollup: 4.58.0
       stacktrace-parser: 0.1.11
@@ -21871,12 +21871,12 @@ snapshots:
       "@opentelemetry/resources": 2.5.1(@opentelemetry/api@1.9.0)
       "@sentry/core": 10.39.0
 
-  "@sentry/webpack-plugin@4.9.1(webpack@5.104.1(esbuild@0.27.3))":
+  "@sentry/webpack-plugin@4.9.1(webpack@5.104.1(esbuild@0.25.12))":
     dependencies:
       "@sentry/bundler-plugin-core": 4.9.1
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.104.1(esbuild@0.27.3)
+      webpack: 5.104.1(esbuild@0.25.12)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -22942,21 +22942,21 @@ snapshots:
       - react-dom
       - react-native
 
-  "@tamagui/next-plugin@1.144.3(@babel/core@7.29.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.27.3))":
+  "@tamagui/next-plugin@1.144.3(@babel/core@7.29.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.25.12))":
     dependencies:
       "@babel/preset-react": 7.28.5(@babel/core@7.29.0)
       "@tamagui/proxy-worm": 1.144.3
       "@tamagui/react-native-svg": 1.144.3(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))
       "@tamagui/static": 1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.104.1(esbuild@0.27.3))
+      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.104.1(esbuild@0.25.12))
       browserslist: 4.28.1
-      css-loader: 6.11.0(webpack@5.104.1(esbuild@0.27.3))
-      esbuild-loader: 4.4.2(webpack@5.104.1(esbuild@0.27.3))
-      file-loader: 6.2.0(webpack@5.104.1(esbuild@0.27.3))
-      html-webpack-plugin: 5.6.5(webpack@5.104.1(esbuild@0.27.3))
+      css-loader: 6.11.0(webpack@5.104.1(esbuild@0.25.12))
+      esbuild-loader: 4.4.2(webpack@5.104.1(esbuild@0.25.12))
+      file-loader: 6.2.0(webpack@5.104.1(esbuild@0.25.12))
+      html-webpack-plugin: 5.6.5(webpack@5.104.1(esbuild@0.25.12))
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      tamagui-loader: 1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.27.3))
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.104.1(esbuild@0.27.3)))(webpack@5.104.1(esbuild@0.27.3))
+      tamagui-loader: 1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.25.12))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.104.1(esbuild@0.25.12)))(webpack@5.104.1(esbuild@0.25.12))
     transitivePeerDependencies:
       - "@babel/core"
       - "@rspack/core"
@@ -24547,12 +24547,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.104.1(esbuild@0.27.3)):
+  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.104.1(esbuild@0.25.12)):
     dependencies:
       "@babel/core": 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.104.1(esbuild@0.27.3)
+      webpack: 5.104.1(esbuild@0.25.12)
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
@@ -25327,7 +25327,7 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
-  css-loader@6.11.0(webpack@5.104.1(esbuild@0.27.3)):
+  css-loader@6.11.0(webpack@5.104.1(esbuild@0.25.12)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -25338,7 +25338,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.4
     optionalDependencies:
-      webpack: 5.104.1(esbuild@0.27.3)
+      webpack: 5.104.1(esbuild@0.25.12)
 
   css-select@4.3.0:
     dependencies:
@@ -25807,12 +25807,12 @@ snapshots:
     dependencies:
       es6-promise: 4.2.8
 
-  esbuild-loader@4.4.2(webpack@5.104.1(esbuild@0.27.3)):
+  esbuild-loader@4.4.2(webpack@5.104.1(esbuild@0.25.12)):
     dependencies:
       esbuild: 0.27.3
       get-tsconfig: 4.13.0
       loader-utils: 2.0.4
-      webpack: 5.104.1(esbuild@0.27.3)
+      webpack: 5.104.1(esbuild@0.25.12)
       webpack-sources: 1.4.3
 
   esbuild-register@3.6.0(esbuild@0.25.12):
@@ -26647,11 +26647,11 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-loader@6.2.0(webpack@5.104.1(esbuild@0.27.3)):
+  file-loader@6.2.0(webpack@5.104.1(esbuild@0.25.12)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.104.1(esbuild@0.27.3)
+      webpack: 5.104.1(esbuild@0.25.12)
 
   file-uri-to-path@1.0.0: {}
 
@@ -27070,7 +27070,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.46.0
 
-  html-webpack-plugin@5.6.5(webpack@5.104.1(esbuild@0.27.3)):
+  html-webpack-plugin@5.6.5(webpack@5.104.1(esbuild@0.25.12)):
     dependencies:
       "@types/html-minifier-terser": 6.1.0
       html-minifier-terser: 6.1.0
@@ -27078,7 +27078,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.0
     optionalDependencies:
-      webpack: 5.104.1(esbuild@0.27.3)
+      webpack: 5.104.1(esbuild@0.25.12)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -30447,7 +30447,7 @@ snapshots:
 
   tailwindcss@4.1.18: {}
 
-  tamagui-loader@1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.27.3)):
+  tamagui-loader@1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(webpack@5.104.1(esbuild@0.25.12)):
     dependencies:
       "@tamagui/cli-color": 1.144.3
       "@tamagui/core": 1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
@@ -30455,7 +30455,7 @@ snapshots:
       "@tamagui/static-worker": 1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       "@tamagui/types": 1.144.3
       "@tamagui/web": 1.144.3(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
-      esbuild-loader: 4.4.2(webpack@5.104.1(esbuild@0.27.3))
+      esbuild-loader: 4.4.2(webpack@5.104.1(esbuild@0.25.12))
       esm-resolve: 1.0.11
       fs-extra: 11.3.3
       loader-utils: 3.3.1
@@ -30553,16 +30553,16 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.16(esbuild@0.27.3)(webpack@5.104.1(esbuild@0.27.3)):
+  terser-webpack-plugin@5.3.16(esbuild@0.25.12)(webpack@5.104.1(esbuild@0.25.12)):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.46.0
-      webpack: 5.104.1(esbuild@0.27.3)
+      webpack: 5.104.1(esbuild@0.25.12)
     optionalDependencies:
-      esbuild: 0.27.3
+      esbuild: 0.25.12
 
   terser@5.46.0:
     dependencies:
@@ -30975,14 +30975,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.104.1(esbuild@0.27.3)))(webpack@5.104.1(esbuild@0.27.3)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.104.1(esbuild@0.25.12)))(webpack@5.104.1(esbuild@0.25.12)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.104.1(esbuild@0.27.3)
+      webpack: 5.104.1(esbuild@0.25.12)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.104.1(esbuild@0.27.3))
+      file-loader: 6.2.0(webpack@5.104.1(esbuild@0.25.12))
 
   url-parse@1.5.10:
     dependencies:
@@ -31241,7 +31241,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.104.1(esbuild@0.27.3):
+  webpack@5.104.1(esbuild@0.25.12):
     dependencies:
       "@types/eslint-scope": 3.7.7
       "@types/estree": 1.0.8
@@ -31265,7 +31265,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.27.3)(webpack@5.104.1(esbuild@0.27.3))
+      terser-webpack-plugin: 5.3.16(esbuild@0.25.12)(webpack@5.104.1(esbuild@0.25.12))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,8 +3,8 @@ packages:
   - packages/*
 
 catalog:
-  "@clerk/clerk-expo": 2.19.26
-  "@clerk/nextjs": 6.38.1
+  "@clerk/clerk-expo": 2.19.36
+  "@clerk/nextjs": 6.39.3
   "@easypost/api": 8.2.0
   "@next/bundle-analyzer": 16.1.6
   "@prisma/client": 6.19.2


### PR DESCRIPTION
## What

Closes the **4 critical** Dependabot advisories on `main` (part of a triage of 143 open alerts: 4 critical / 73 high / 51 medium / 15 low).

| Alert | Package | Advisory | Fix |
|---|---|---|---|
| #114 | `@clerk/nextjs` 6.38.1 → **6.39.3** | GHSA-vqx2-fgx2-5wq9 — middleware route-protection **bypass** | catalog bump |
| #113 | `@clerk/shared` → **3.47.7** (transitive) | same GHSA | via Clerk bump |
| #161 | `shell-quote` → **1.9.0** | GHSA-w7jw-789q-3m8p — arg injection (newlines not escaped) | `pnpm.overrides` |
| #63 | `simple-git` → **3.36.0** | GHSA-r275-fr43-pm7q — **RCE** via case-insensitive protocol.allow bypass | `pnpm.overrides` |

`@clerk/clerk-expo` is also bumped 2.19.26 → 2.19.36 (same Clerk SDK advisory, mobile app). The Clerk bump transitively pulls `@clerk/backend` 2.33.5, `@clerk/clerk-js` 5.127.0, `@clerk/clerk-react` 5.61.8 to patched (clears the related highs too).

## How

- Direct deps live in the `pnpm-workspace.yaml` **catalog** → bumped there.
- `shell-quote` / `simple-git` are transitive → pinned via `pnpm.overrides` (both single-major, patch-level, low blast radius).
- No semver-major bumps (respects the repo's Dependabot policy). Nothing in the platform-core (Tamagui/Expo/RN/Solito) tier is touched.

## Verification

- `pnpm install` resolves clean; each fixed package resolves to a single patched version (no vulnerable copies left in the lockfile).
- Lockfile diff is small because the pre-commit Prettier hook keeps it in the repo's committed format.

Follow-up PR (stacked on this branch) will handle the 73 highs. **Not** merging until the automated review lands.