### PR TITLE
fix: Tamagui audit bugs — config alias, dark-mode greys, metro transformer

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -35,7 +35,8 @@ singletonPackages.forEach((pkg) => {
 // Configure SVG support with react-native-svg-transformer
 config.transformer = {
   ...config.transformer,
-  babelTransformerPath: require.resolve("react-native-svg-transformer"),
+  // Use the /expo entry so Expo's own babel transformer stays in the chain
+  babelTransformerPath: require.resolve("react-native-svg-transformer/expo"),
 };
 
 config.resolver = {

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -177,8 +177,10 @@ module.exports = () => {
         "@tamagui/web": require.resolve("@tamagui/web"),
         // Explicit alias for @tamagui/polyfill-dev to fix webpack resolution in pnpm monorepo
         "@tamagui/polyfill-dev": require.resolve("@tamagui/polyfill-dev"),
-        // Enforce single instance of config to prevent "Missing theme" errors from duplicate modules
-        "@buttergolf/config": resolve(__dirname, "../../packages/config/src/tamagui.config.ts"),
+        // Enforce single instance of config to prevent "Missing theme" errors from duplicate modules.
+        // Must point at the package index (not tamagui.config.ts directly) so named exports
+        // like brandColors keep resolving.
+        "@buttergolf/config": resolve(__dirname, "../../packages/config/src/index.ts"),
       };
 
       // Add .web.ts/.web.tsx extensions for platform-specific files (React Native pattern)

--- a/packages/app/src/features/orders/order-detail-screen.tsx
+++ b/packages/app/src/features/orders/order-detail-screen.tsx
@@ -460,7 +460,7 @@ export function OrderDetailScreen({
                   width={28}
                   height={28}
                   borderRadius="$full"
-                  backgroundColor={step.completed ? "$primary" : "$gray200"}
+                  backgroundColor={step.completed ? "$primary" : "$backgroundHover"}
                   alignItems="center"
                   justifyContent="center"
                 >
@@ -527,7 +527,12 @@ export function OrderDetailScreen({
 
         {/* Payment Released */}
         {order.paymentHoldStatus === "RELEASED" && (
-          <Column backgroundColor="$gray100" borderRadius="$lg" padding="$4" marginBottom="$4">
+          <Column
+            backgroundColor="$backgroundHover"
+            borderRadius="$lg"
+            padding="$4"
+            marginBottom="$4"
+          >
             <Row alignItems="center" gap="$2">
               <CheckCircle size={20} color="$success" />
               <Text size="$4" fontWeight="600" color="$success">
@@ -563,14 +568,14 @@ export function OrderDetailScreen({
                 width={90}
                 height={90}
                 borderRadius="$md"
-                backgroundColor="$gray100"
+                backgroundColor="$backgroundHover"
               />
             ) : (
               <View
                 width={90}
                 height={90}
                 borderRadius="$md"
-                backgroundColor="$gray100"
+                backgroundColor="$backgroundHover"
                 alignItems="center"
                 justifyContent="center"
               >
@@ -588,7 +593,7 @@ export function OrderDetailScreen({
                 </Text>
               )}
               {order.product.condition && (
-                <Badge backgroundColor="$gray200" alignSelf="flex-start" marginTop="$1">
+                <Badge backgroundColor="$backgroundHover" alignSelf="flex-start" marginTop="$1">
                   <Text size="$2" color="$text">
                     {order.product.condition}
                   </Text>
@@ -824,7 +829,7 @@ export function OrderDetailScreen({
                 width={44}
                 height={44}
                 borderRadius="$full"
-                backgroundColor="$gray200"
+                backgroundColor="$backgroundHover"
                 alignItems="center"
                 justifyContent="center"
               >


### PR DESCRIPTION
First of a series of PRs from the Tamagui design-system audit. Bug fixes only, no behaviour redesign.

## Changes

1. **`@buttergolf/config` webpack alias** ([apps/web/next.config.js](../blob/HEAD/apps/web/next.config.js)) — was aliased to `tamagui.config.ts`, which doesn't export `brandColors` (that lives in `brand-colors.ts`, re-exported via the package index). Three pages (`mobile-onboarding`, `SellOnboardingGate`, `PayoutSetupWizard`) import `brandColors` and dereference it at render → TypeError. Alias now points at `src/index.ts`; single-instance guarantee unchanged.
2. **Dark-mode rendering bug** (`packages/app/src/features/orders/order-detail-screen.tsx`) — six uses of `$gray100`/`$gray200` (fixed light greys, not theme keys) replaced with `$backgroundHover`. Light mode near-identical (#EDEDED vs #F5F5F5); dark mode no longer shows light-grey blocks (e.g. "Payment Released" card).
3. **Metro transformer** (`apps/mobile/metro.config.js`) — `react-native-svg-transformer` → `react-native-svg-transformer/expo`. The bare entry chains to `@react-native/metro-babel-transformer`, displacing Expo's `@expo/metro-config/babel-transformer` app-wide (virtual modules, CSS, import.meta handling).

## Test plan

- `pnpm check` passes (format + lint + type-check, all workspaces)
- Web: load `/mobile-onboarding`, `/sell` gate, account payout wizard — no TypeError
- Mobile: order detail screen in dark mode — no light-grey blocks; SVG imports still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)