### PR TITLE
refactor: delete Text weight/align variants, adopt native fontWeight/textAlign

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -454,6 +454,7 @@ The design system rules above are enforced. Before committing, verify:
 - [ ] No `fontSize` prop on Text components (use `size` instead) - ESLint blocks this
 - [ ] No hardcoded hex colors (use semantic tokens like `$primary`, `$text`)
 - [ ] No raw pixel values for spacing (use `$xs`, `$sm`, `$md`, `$lg`, `$xl`, `$2xl`, `$3xl`)
+- [ ] Named spacing scale is canonical for padding/margin/gap; numeric space tokens (`$1`-`$20`) are legacy — don't add new ones, migrate opportunistically
 - [ ] All form inputs use design system components (Input, Select, TextArea, Radio)
 - [ ] Brand colours (Vanilla Cream, Lemon Haze) used where appropriate for visual interest
 

--- a/.github/DESIGN_SYSTEM_RULES.md
+++ b/.github/DESIGN_SYSTEM_RULES.md
@@ -127,19 +127,19 @@ Uses numeric tokens `$1` through `$16`:
 
 #### Core Components
 
-| Component      | Location           | Description                            |
-| -------------- | ------------------ | -------------------------------------- |
-| `Button`       | `Button.tsx`       | Primary/secondary buttons with shadows |
-| `AuthButton`   | `AuthButton.tsx`   | Authentication-specific buttons        |
+| Component      | Location           | Description                                 |
+| -------------- | ------------------ | ------------------------------------------- |
+| `Button`       | `Button.tsx`       | Primary/secondary buttons with shadows      |
+| `AuthButton`   | `AuthButton.tsx`   | Authentication-specific buttons             |
 | `Text`         | `Text.tsx`         | Body text (use native fontWeight/textAlign) |
-| `Heading`      | `Text.tsx`         | h1-h6 headings with level prop         |
-| `Label`        | `Text.tsx`         | Form labels                            |
-| `Input`        | `Input.tsx`        | Text inputs with size variants         |
-| `TextArea`     | `TextArea.tsx`     | Multi-line text input                  |
-| `Checkbox`     | `Checkbox.tsx`     | Checkbox control                       |
-| `Radio`        | `Radio.tsx`        | Radio button group                     |
-| `Slider`       | `Slider.tsx`       | Slider control                         |
-| `Autocomplete` | `Autocomplete.tsx` | Autocomplete input                     |
+| `Heading`      | `Text.tsx`         | h1-h6 headings with level prop              |
+| `Label`        | `Text.tsx`         | Form labels                                 |
+| `Input`        | `Input.tsx`        | Text inputs with size variants              |
+| `TextArea`     | `TextArea.tsx`     | Multi-line text input                       |
+| `Checkbox`     | `Checkbox.tsx`     | Checkbox control                            |
+| `Radio`        | `Radio.tsx`        | Radio button group                          |
+| `Slider`       | `Slider.tsx`       | Slider control                              |
+| `Autocomplete` | `Autocomplete.tsx` | Autocomplete input                          |
 
 #### Layout Components
 

--- a/.github/DESIGN_SYSTEM_RULES.md
+++ b/.github/DESIGN_SYSTEM_RULES.md
@@ -131,14 +131,14 @@ Uses numeric tokens `$1` through `$16`:
 | -------------- | ------------------ | -------------------------------------- |
 | `Button`       | `Button.tsx`       | Primary/secondary buttons with shadows |
 | `AuthButton`   | `AuthButton.tsx`   | Authentication-specific buttons        |
-| `Text`         | `Text.tsx`         | Body text with weight/align variants   |
+| `Text`         | `Text.tsx`         | Body text (use native fontWeight/textAlign) |
 | `Heading`      | `Text.tsx`         | h1-h6 headings with level prop         |
 | `Label`        | `Text.tsx`         | Form labels                            |
 | `Input`        | `Input.tsx`        | Text inputs with size variants         |
 | `TextArea`     | `TextArea.tsx`     | Multi-line text input                  |
 | `Checkbox`     | `Checkbox.tsx`     | Checkbox control                       |
 | `Radio`        | `Radio.tsx`        | Radio button group                     |
-| `Slider`       | `Slider.tsx`       | Range slider                           |
+| `Slider`       | `Slider.tsx`       | Slider control                         |
 | `Autocomplete` | `Autocomplete.tsx` | Autocomplete input                     |
 
 #### Layout Components

--- a/apps/web/src/app/_components/header/ButterHeader.tsx
+++ b/apps/web/src/app/_components/header/ButterHeader.tsx
@@ -154,7 +154,7 @@ export function ButterHeader() {
                     transition: "all 200ms ease-out",
                   }}
                 >
-                  <Text size="$6" weight={isActive("/") ? "bold" : "normal"} color="$text">
+                  <Text size="$6" fontWeight={isActive("/") ? "700" : "400"} color="$text">
                     Home
                   </Text>
                 </Row>
@@ -173,7 +173,7 @@ export function ButterHeader() {
                     transition: "all 200ms ease-out",
                   }}
                 >
-                  <Text size="$6" weight={isActive("/listings") ? "bold" : "normal"} color="$text">
+                  <Text size="$6" fontWeight={isActive("/listings") ? "700" : "400"} color="$text">
                     Buying
                   </Text>
                 </Row>
@@ -192,7 +192,7 @@ export function ButterHeader() {
                     transition: "all 200ms ease-out",
                   }}
                 >
-                  <Text size="$6" weight={isActive("/sell") ? "bold" : "normal"} color="$text">
+                  <Text size="$6" fontWeight={isActive("/sell") ? "700" : "400"} color="$text">
                     Selling
                   </Text>
                 </Row>
@@ -314,7 +314,7 @@ export function ButterHeader() {
           >
             <Text
               size="$7"
-              weight={isActive("/") ? "bold" : "normal"}
+              fontWeight={isActive("/") ? "700" : "400"}
               color={isActive("/") ? "$primary" : "$text"}
             >
               Home
@@ -327,7 +327,7 @@ export function ButterHeader() {
           >
             <Text
               size="$7"
-              weight={isActive("/listings") ? "bold" : "normal"}
+              fontWeight={isActive("/listings") ? "700" : "400"}
               color={isActive("/listings") ? "$primary" : "$text"}
             >
               Buying
@@ -340,7 +340,7 @@ export function ButterHeader() {
           >
             <Text
               size="$7"
-              weight={isActive("/sell") ? "bold" : "normal"}
+              fontWeight={isActive("/sell") ? "700" : "400"}
               color={isActive("/sell") ? "$primary" : "$text"}
             >
               Selling
@@ -355,7 +355,7 @@ export function ButterHeader() {
           >
             <Text
               size="$7"
-              weight={isActive("/favourites") ? "bold" : "normal"}
+              fontWeight={isActive("/favourites") ? "700" : "400"}
               color={isActive("/favourites") ? "$primary" : "$text"}
             >
               Wishlist
@@ -369,7 +369,7 @@ export function ButterHeader() {
             <Row alignItems="center" gap="$2">
               <Text
                 size="$7"
-                weight={isActive("/messages") ? "bold" : "normal"}
+                fontWeight={isActive("/messages") ? "700" : "400"}
                 color={isActive("/messages") ? "$primary" : "$text"}
               >
                 Messages
@@ -398,7 +398,7 @@ export function ButterHeader() {
           >
             <Text
               size="$7"
-              weight={isActive("/orders") ? "bold" : "normal"}
+              fontWeight={isActive("/orders") ? "700" : "400"}
               color={isActive("/orders") ? "$primary" : "$text"}
             >
               Orders
@@ -411,7 +411,7 @@ export function ButterHeader() {
           >
             <Text
               size="$7"
-              weight={isActive("/account") ? "bold" : "normal"}
+              fontWeight={isActive("/account") ? "700" : "400"}
               color={isActive("/account") ? "$primary" : "$text"}
             >
               Account
@@ -423,7 +423,7 @@ export function ButterHeader() {
 
           {/* Category Navigation - Mobile Only */}
           <Column gap="$4">
-            <Text size="$5" weight="semibold" color="$textSecondary">
+            <Text size="$5" fontWeight="600" color="$textSecondary">
               Shop by Category
             </Text>
             {NAV_CATEGORIES.map((category) => (
@@ -436,7 +436,7 @@ export function ButterHeader() {
                 <Row minHeight={44} alignItems="center" paddingVertical="$2">
                   <Text
                     size="$6"
-                    weight={isActive(category.href) ? "bold" : "normal"}
+                    fontWeight={isActive(category.href) ? "700" : "400"}
                     color={isActive(category.href) ? "$primary" : "$text"}
                   >
                     {category.name}
@@ -449,7 +449,7 @@ export function ButterHeader() {
           {/* Theme Switcher - Mobile */}
           <Row height={1} backgroundColor="$border" marginVertical="$2" width="100%" />
           <Row alignItems="center" justifyContent="space-between" paddingVertical="$2">
-            <Text size="$5" weight="semibold" color="$textSecondary">
+            <Text size="$5" fontWeight="600" color="$textSecondary">
               Theme
             </Text>
             <ThemeSwitcher showLabels />

--- a/apps/web/src/app/_components/header/DesktopMenu.tsx
+++ b/apps/web/src/app/_components/header/DesktopMenu.tsx
@@ -45,7 +45,7 @@ export function DesktopMenu({ menuData }: Readonly<DesktopMenuProps>) {
                     borderWidth={0}
                     hoverStyle={{ backgroundColor: "$backgroundHover" }}
                   >
-                    <Text size="$3" weight="medium" whiteSpace="nowrap">
+                    <Text size="$3" fontWeight="500" whiteSpace="nowrap">
                       {menuItem.title}
                     </Text>
                     <Column
@@ -94,7 +94,7 @@ export function DesktopMenu({ menuData }: Readonly<DesktopMenuProps>) {
                             borderRadius="$md"
                             hoverStyle={{ backgroundColor: "$backgroundHover" }}
                           >
-                            <Text size="$3" weight="medium">
+                            <Text size="$3" fontWeight="500">
                               {subItem.title}
                             </Text>
                           </Row>
@@ -113,7 +113,7 @@ export function DesktopMenu({ menuData }: Readonly<DesktopMenuProps>) {
                     borderRadius="$md"
                     hoverStyle={{ backgroundColor: "$backgroundHover" }}
                   >
-                    <Text size="$3" weight="medium">
+                    <Text size="$3" fontWeight="500">
                       {menuItem.title}
                     </Text>
                   </Row>

--- a/apps/web/src/app/_components/header/SearchDropdown.tsx
+++ b/apps/web/src/app/_components/header/SearchDropdown.tsx
@@ -69,7 +69,7 @@ export function SearchDropdown({ query, onSelect }: SearchDropdownProps) {
   if (query.trim().length < 2) {
     return (
       <Column padding="$4" gap="$3">
-        <Text size="$3" weight="medium" {...{ color: "$textMuted" }}>
+        <Text size="$3" fontWeight="500" {...{ color: "$textMuted" }}>
           Type to search for golf equipment...
         </Text>
         <Column gap="$2">
@@ -111,7 +111,7 @@ export function SearchDropdown({ query, onSelect }: SearchDropdownProps) {
   if (error) {
     return (
       <Column padding="$6" alignItems="center" gap="$2">
-        <Text size="$4" weight="semibold" {...{ color: "$error" }}>
+        <Text size="$4" fontWeight="600" {...{ color: "$error" }}>
           Search Error
         </Text>
         <Text {...{ color: "$textMuted" }} size="$3">
@@ -125,10 +125,10 @@ export function SearchDropdown({ query, onSelect }: SearchDropdownProps) {
   if (results.length === 0) {
     return (
       <Column padding="$6" alignItems="center" gap="$2">
-        <Text size="$4" weight="semibold">
+        <Text size="$4" fontWeight="600">
           No results found
         </Text>
-        <Text {...{ color: "$textMuted" }} size="$3" align="center">
+        <Text {...{ color: "$textMuted" }} size="$3" textAlign="center">
           Try a different search term or browse our categories
         </Text>
       </Column>
@@ -157,9 +157,9 @@ export function SearchDropdown({ query, onSelect }: SearchDropdownProps) {
           <Link href={`/listings?q=${encodeURIComponent(query)}`} onClick={onSelect}>
             <Text
               size="$3"
-              weight="medium"
+              fontWeight="500"
               {...{ color: "$primary" }}
-              align="center"
+              textAlign="center"
               hoverStyle={{ textDecoration: "underline" }}
               cursor="pointer"
             >

--- a/apps/web/src/app/_components/header/SearchResultItem.tsx
+++ b/apps/web/src/app/_components/header/SearchResultItem.tsx
@@ -32,7 +32,7 @@ export function SearchResultItem({ product, onSelect }: SearchResultItemProps) {
 
         {/* Product Details */}
         <Column flex={1} gap="$xs">
-          <Text weight="semibold" numberOfLines={1} size="$3">
+          <Text fontWeight="600" numberOfLines={1} size="$3">
             {product.title}
           </Text>
           <Row gap="$2" alignItems="center" flexWrap="wrap">
@@ -48,7 +48,7 @@ export function SearchResultItem({ product, onSelect }: SearchResultItemProps) {
         </Column>
 
         {/* Price */}
-        <Text weight="bold" {...{ color: "$primary" }} flexShrink={0}>
+        <Text fontWeight="700" {...{ color: "$primary" }} flexShrink={0}>
           £{product.price.toFixed(2)}
         </Text>
       </Row>

--- a/apps/web/src/app/_components/marketplace/FooterSection.tsx
+++ b/apps/web/src/app/_components/marketplace/FooterSection.tsx
@@ -79,7 +79,7 @@ export function FooterSection() {
                 <Text
                   color="$vanillaCream"
                   size="$4"
-                  weight="bold"
+                  fontWeight="700"
                   cursor="pointer"
                   hoverStyle={{ opacity: 0.8 }}
                 >
@@ -90,7 +90,7 @@ export function FooterSection() {
                 <Text
                   color="$vanillaCream"
                   size="$4"
-                  weight="bold"
+                  fontWeight="700"
                   cursor="pointer"
                   hoverStyle={{ opacity: 0.8 }}
                 >
@@ -101,7 +101,7 @@ export function FooterSection() {
                 <Text
                   color="$vanillaCream"
                   size="$4"
-                  weight="bold"
+                  fontWeight="700"
                   cursor="pointer"
                   hoverStyle={{ opacity: 0.8 }}
                 >
@@ -172,7 +172,7 @@ export function FooterSection() {
             alignItems="center"
             gap="$sm"
           >
-            <Text size="$4" weight="semibold" color="$success">
+            <Text size="$4" fontWeight="600" color="$success">
               ★ Trustpilot
             </Text>
             <Text size="$3" color="$textSecondary">

--- a/apps/web/src/app/_components/marketplace/NewsletterSection.tsx
+++ b/apps/web/src/app/_components/marketplace/NewsletterSection.tsx
@@ -77,7 +77,7 @@ export function NewsletterSection() {
         alignItems="center"
       >
         <Column gap="$sm" alignItems="center">
-          <Text size="$8" weight="bold" color="$text" textAlign="center">
+          <Text size="$8" fontWeight="700" color="$text" textAlign="center">
             Don&apos;t miss deals
           </Text>
           <Text color="$textSecondary" size="$5" textAlign="center">
@@ -133,7 +133,7 @@ export function NewsletterSection() {
               {status === "submitting" ? (
                 <Row alignItems="center" justifyContent="center" gap="$sm" width="100%">
                   <Spinner size="sm" color="$white" alignSelf="center" />
-                  <Text size="$5" color="$white" weight="bold">
+                  <Text size="$5" color="$white" fontWeight="700">
                     Subscribing...
                   </Text>
                 </Row>
@@ -151,7 +151,7 @@ export function NewsletterSection() {
                   <Text
                     size="$5"
                     color="$white"
-                    weight="bold"
+                    fontWeight="700"
                     animation="quick"
                     opacity={status === "successTick" ? 0 : 1}
                     x={status === "successTick" ? 8 : 0}

--- a/apps/web/src/app/_components/marketplace/TrustBar.tsx
+++ b/apps/web/src/app/_components/marketplace/TrustBar.tsx
@@ -26,13 +26,13 @@ export function TrustBar() {
       }}
     >
       <Row alignItems="center" justifyContent="center" flexWrap="wrap" gap="$xs">
-        <Text size="$3" weight="medium" color="$text">
+        <Text size="$3" fontWeight="500" color="$text">
           Give 10%, Get 10%.
         </Text>
         <Link href="/refer-a-friend" style={{ textDecoration: "none" }}>
           <Text
             size="$3"
-            weight="medium"
+            fontWeight="500"
             color="$primary"
             textDecorationLine="underline"
             cursor="pointer"

--- a/apps/web/src/app/_components/marketplace/TrustSection.tsx
+++ b/apps/web/src/app/_components/marketplace/TrustSection.tsx
@@ -85,10 +85,10 @@ export function TrustSection() {
 
               {/* Text */}
               <Column gap="$xs">
-                <Text size="$7" weight="bold" color="$text">
+                <Text size="$7" fontWeight="700" color="$text">
                   {item.title}
                 </Text>
-                <Text size="$7" weight="bold" color="$text">
+                <Text size="$7" fontWeight="700" color="$text">
                   {item.subtitle}
                 </Text>
               </Column>

--- a/apps/web/src/app/_components/marketplace/seller-hub/EditProductModal.tsx
+++ b/apps/web/src/app/_components/marketplace/seller-hub/EditProductModal.tsx
@@ -224,7 +224,7 @@ export function EditProductModal({ product, onClose, onSave }: EditProductModalP
             <Column gap="$lg" padding="$lg">
               {/* Images */}
               <Column gap="$xs">
-                <Text weight="medium">Photos *</Text>
+                <Text fontWeight="500">Photos *</Text>
                 <ImageUpload
                   onUploadComplete={handleImageUploadComplete}
                   onRemoveImage={handleRemoveImage}
@@ -236,7 +236,7 @@ export function EditProductModal({ product, onClose, onSave }: EditProductModalP
 
               {/* Title */}
               <Column gap="$xs">
-                <Text weight="medium">Title *</Text>
+                <Text fontWeight="500">Title *</Text>
                 <Input
                   value={formData.title}
                   onChangeText={(value) => setFormData({ ...formData, title: value })}
@@ -248,7 +248,7 @@ export function EditProductModal({ product, onClose, onSave }: EditProductModalP
 
               {/* Description */}
               <Column gap="$xs">
-                <Text weight="medium">Description *</Text>
+                <Text fontWeight="500">Description *</Text>
                 {/* eslint-disable-next-line react/forbid-elements */}
                 <textarea
                   value={formData.description}
@@ -273,7 +273,7 @@ export function EditProductModal({ product, onClose, onSave }: EditProductModalP
               {/* Price & Condition */}
               <Row gap="$md" flexWrap="wrap">
                 <Column gap="$xs" flex={1} minWidth={200}>
-                  <Text weight="medium">Price (£) *</Text>
+                  <Text fontWeight="500">Price (£) *</Text>
                   <Input
                     value={formData.price}
                     onChangeText={(value) => setFormData({ ...formData, price: value })}
@@ -290,7 +290,7 @@ export function EditProductModal({ product, onClose, onSave }: EditProductModalP
                 </Column>
 
                 <Column gap="$xs" flex={1} minWidth={200}>
-                  <Text weight="medium">Condition *</Text>
+                  <Text fontWeight="500">Condition *</Text>
                   {/* eslint-disable-next-line react/forbid-elements */}
                   <select
                     value={formData.condition}
@@ -330,7 +330,7 @@ export function EditProductModal({ product, onClose, onSave }: EditProductModalP
 
               {/* Brand */}
               <Column gap="$xs">
-                <Text weight="medium">Brand *</Text>
+                <Text fontWeight="500">Brand *</Text>
                 {/* eslint-disable-next-line react/forbid-elements */}
                 <select
                   value={formData.brandId}
@@ -369,7 +369,7 @@ export function EditProductModal({ product, onClose, onSave }: EditProductModalP
 
               {/* Model */}
               <Column gap="$xs">
-                <Text weight="medium">Model</Text>
+                <Text fontWeight="500">Model</Text>
                 <Input
                   value={formData.model}
                   onChangeText={(value) => setFormData({ ...formData, model: value })}
@@ -380,7 +380,7 @@ export function EditProductModal({ product, onClose, onSave }: EditProductModalP
 
               {/* Category */}
               <Column gap="$xs">
-                <Text weight="medium">Category *</Text>
+                <Text fontWeight="500">Category *</Text>
                 {/* eslint-disable-next-line react/forbid-elements */}
                 <select
                   value={formData.categoryId}

--- a/apps/web/src/app/_components/marketplace/seller-hub/SellerHub.tsx
+++ b/apps/web/src/app/_components/marketplace/seller-hub/SellerHub.tsx
@@ -278,7 +278,7 @@ export function SellerHub() {
           <Heading level={2} textAlign="center">
             Ready to list your first item?
           </Heading>
-          <Text size="$5" align="center" color="$textSecondary">
+          <Text size="$5" textAlign="center" color="$textSecondary">
             Listing your golf equipment is quick and easy — it takes under 60 seconds to get
             started.
           </Text>
@@ -314,7 +314,7 @@ export function SellerHub() {
             <Button butterVariant="primary" size="$5">
               <Row gap="$sm" alignItems="center">
                 <Plus size={20} color="white" />
-                <Text color="$textInverse" weight="semibold">
+                <Text color="$textInverse" fontWeight="600">
                   New Listing
                 </Text>
               </Row>
@@ -325,7 +325,7 @@ export function SellerHub() {
         {successMessage && (
           <Card variant="filled" padding="$md" backgroundColor="$successLight" borderRadius="$md">
             <Row alignItems="center" justifyContent="space-between" gap="$md" flexWrap="wrap">
-              <Text color="$success" weight="semibold">
+              <Text color="$success" fontWeight="600">
                 {successMessage}
               </Text>
               <Row gap="$sm" alignItems="center">
@@ -351,7 +351,7 @@ export function SellerHub() {
                   <Package size={20} color="$primary" />
                   <Text color="$textSecondary">Total Listings</Text>
                 </Row>
-                <Text size="$9" weight="bold">
+                <Text size="$9" fontWeight="700">
                   {data.stats.totalListings}
                 </Text>
                 <Text size="$3" color="$textSecondary">
@@ -366,7 +366,7 @@ export function SellerHub() {
                   <Eye size={20} color="$secondary" />
                   <Text color="$textSecondary">Total Views</Text>
                 </Row>
-                <Text size="$9" weight="bold">
+                <Text size="$9" fontWeight="700">
                   {data.stats.totalViews}
                 </Text>
                 <Text size="$3" color="$textSecondary">
@@ -381,7 +381,7 @@ export function SellerHub() {
                   <Heart size={20} color="$error" />
                   <Text color="$textSecondary">Total Favourites</Text>
                 </Row>
-                <Text size="$9" weight="bold">
+                <Text size="$9" fontWeight="700">
                   {data.stats.totalFavourites}
                 </Text>
                 <Text size="$3" color="$textSecondary">
@@ -396,7 +396,7 @@ export function SellerHub() {
                   <Tag size={20} color="$warning" />
                   <Text color="$textSecondary">Pending Offers</Text>
                 </Row>
-                <Text size="$9" weight="bold">
+                <Text size="$9" fontWeight="700">
                   {data.stats.pendingOffers}
                 </Text>
                 <Text size="$3" color="$textSecondary">
@@ -412,7 +412,7 @@ export function SellerHub() {
           <Row gap="$md" alignItems="center" flexWrap="wrap" justifyContent="space-between">
             {/* Status Filter */}
             <Row gap="$sm" alignItems="center" flexWrap="wrap">
-              <Text weight="medium">Status:</Text>
+              <Text fontWeight="500">Status:</Text>
               <Row gap="$xs">
                 {(["all", "active", "sold", "draft"] as const).map((status) => (
                   <Theme key={status} name={statusFilter === status ? "active" : null}>
@@ -442,7 +442,7 @@ export function SellerHub() {
 
             {/* Sort */}
             <Row gap="$sm" alignItems="center">
-              <Text weight="medium">Sort:</Text>
+              <Text fontWeight="500">Sort:</Text>
               {/* eslint-disable-next-line react/forbid-elements */}
               <select
                 value={sortBy}

--- a/apps/web/src/app/_components/marketplace/seller-hub/SellerProductCard.tsx
+++ b/apps/web/src/app/_components/marketplace/seller-hub/SellerProductCard.tsx
@@ -187,7 +187,7 @@ export function SellerProductCard({
             >
               <Text
                 size="$5"
-                weight="semibold"
+                fontWeight="600"
                 color="$text"
                 numberOfLines={2}
                 hoverStyle={{ color: "$primary" }}
@@ -196,7 +196,7 @@ export function SellerProductCard({
               </Text>
             </Link>
             <Row gap="$sm" alignItems="center">
-              <Text size="$6" weight="bold" color="$primary">
+              <Text size="$6" fontWeight="700" color="$primary">
                 £{product.price.toFixed(2)}
               </Text>
               <Text size="$3" color="$textSecondary">
@@ -253,7 +253,7 @@ export function SellerProductCard({
               >
                 <Row gap="$xs" alignItems="center">
                   <Zap size={14} color="$text" />
-                  <Text color="$text" weight="semibold">
+                  <Text color="$text" fontWeight="600">
                     Boost
                   </Text>
                 </Row>
@@ -267,7 +267,7 @@ export function SellerProductCard({
                 <Button butterVariant="primary" size="$4" width="100%" disabled={isDeleting}>
                   <Row gap="$xs" alignItems="center">
                     <Edit3 size={14} color="$textInverse" />
-                    <Text color="$textInverse" weight="semibold">
+                    <Text color="$textInverse" fontWeight="600">
                       Continue Editing
                     </Text>
                   </Row>
@@ -284,7 +284,7 @@ export function SellerProductCard({
                 >
                   <Row gap="$xs" alignItems="center">
                     <Edit3 size={14} color="$text" />
-                    <Text color="$text" weight="semibold">
+                    <Text color="$text" fontWeight="600">
                       Edit
                     </Text>
                   </Row>

--- a/apps/web/src/app/account/_components/AccountSettingsClient.tsx
+++ b/apps/web/src/app/account/_components/AccountSettingsClient.tsx
@@ -176,12 +176,12 @@ export function AccountSettingsClient({ user }: AccountSettingsClientProps) {
           <Column gap="$md">
             <Heading level={3}>Account Information</Heading>
             <Column gap="$xs">
-              <Text weight="medium">Email</Text>
+              <Text fontWeight="500">Email</Text>
               <Text color="$textSecondary">{user.email}</Text>
             </Column>
             {(user.firstName || user.lastName) && (
               <Column gap="$xs">
-                <Text weight="medium">Name</Text>
+                <Text fontWeight="500">Name</Text>
                 <Text color="$textSecondary">
                   {`${user.firstName || ""} ${user.lastName || ""}`.trim()}
                 </Text>
@@ -189,7 +189,7 @@ export function AccountSettingsClient({ user }: AccountSettingsClientProps) {
             )}
             {user.phone && (
               <Column gap="$xs">
-                <Text weight="medium">Phone</Text>
+                <Text fontWeight="500">Phone</Text>
                 <Text color="$textSecondary">{user.phone}</Text>
               </Column>
             )}

--- a/apps/web/src/app/account/addresses/page.tsx
+++ b/apps/web/src/app/account/addresses/page.tsx
@@ -54,7 +54,7 @@ function formatUKPostcode(postcode: string): string {
 // Form Label component
 const FormLabel = ({ children, required }: { children: React.ReactNode; required?: boolean }) => (
   <Row gap="$xs" marginBottom="$xs">
-    <Text size="$3" weight="medium" color="$text">
+    <Text size="$3" fontWeight="500" color="$text">
       {children}
     </Text>
     {required && <Text color="$error">*</Text>}
@@ -436,7 +436,7 @@ export default function AddressesPage() {
                 <Row justifyContent="space-between" alignItems="flex-start">
                   <Column gap="$sm" flex={1}>
                     <Row gap="$sm" alignItems="center">
-                      <Text size="$6" weight="semibold">
+                      <Text size="$6" fontWeight="600">
                         {address.firstName && address.lastName
                           ? `${address.firstName} ${address.lastName}`
                           : address.name}

--- a/apps/web/src/app/account/payment-methods/page.tsx
+++ b/apps/web/src/app/account/payment-methods/page.tsx
@@ -55,7 +55,7 @@ export default function PaymentMethodsPage() {
           <Row gap="$md" alignItems="flex-start">
             <Lightbulb size={20} color="$secondary" />
             <Column gap="$xs" flex={1}>
-              <Text weight="medium" color="$secondary">
+              <Text fontWeight="500" color="$secondary">
                 Looking for payout settings?
               </Text>
               <Text size="$4" color="$textSecondary">

--- a/apps/web/src/app/cart/page.tsx
+++ b/apps/web/src/app/cart/page.tsx
@@ -16,7 +16,7 @@ export default function CartPage() {
         gap="$4"
         paddingHorizontal="$4"
       >
-        <Text size="$7" weight="bold">
+        <Text size="$7" fontWeight="700">
           Your cart is empty
         </Text>
         <Text color="$textSecondary">Browse our marketplace to find great deals</Text>
@@ -39,7 +39,7 @@ export default function CartPage() {
       width="100%"
     >
       <Row alignItems="center" justifyContent="space-between">
-        <Text size="$7" weight="bold">
+        <Text size="$7" fontWeight="700">
           Shopping Cart ({items.length} {items.length === 1 ? "item" : "items"})
         </Text>
         <Button chromeless onPress={clearCart}>
@@ -62,10 +62,10 @@ export default function CartPage() {
                   alt={item.title}
                 />
                 <Column flex={1} gap="$2">
-                  <Text size="$4" weight="semibold">
+                  <Text size="$4" fontWeight="600">
                     {item.title}
                   </Text>
-                  <Text size="$6" weight="bold" color="$primary">
+                  <Text size="$6" fontWeight="700" color="$primary">
                     £{item.price.toFixed(2)}
                   </Text>
                 </Column>
@@ -97,7 +97,7 @@ export default function CartPage() {
         {/* Order Summary */}
         <Card variant="elevated" padding="$lg" minWidth={300} width="100%" maxWidth={400}>
           <Column gap="$4">
-            <Text size="$6" weight="bold">
+            <Text size="$6" fontWeight="700">
               Order Summary
             </Text>
             <Column gap="$2">
@@ -117,10 +117,10 @@ export default function CartPage() {
               justifyContent="space-between"
               alignItems="center"
             >
-              <Text size="$6" weight="bold">
+              <Text size="$6" fontWeight="700">
                 Total
               </Text>
-              <Text size="$7" weight="bold" color="$primary">
+              <Text size="$7" fontWeight="700" color="$primary">
                 £{totalPrice.toFixed(2)}
               </Text>
             </Row>

--- a/apps/web/src/app/checkout/cancel/page.tsx
+++ b/apps/web/src/app/checkout/cancel/page.tsx
@@ -34,7 +34,7 @@ export default function CheckoutCancelPage() {
           {/* Cancel Message */}
           <Column gap="$sm" alignItems="center">
             <Heading level={2}>Checkout Cancelled</Heading>
-            <Text color="$textSecondary" align="center">
+            <Text color="$textSecondary" textAlign="center">
               Your payment was cancelled. No charges were made to your account.
             </Text>
           </Column>
@@ -42,7 +42,7 @@ export default function CheckoutCancelPage() {
           {/* Information */}
           <Card variant="outlined" padding="$lg" fullWidth>
             <Column gap="$md">
-              <Text weight="semibold">Why was my checkout cancelled?</Text>
+              <Text fontWeight="600">Why was my checkout cancelled?</Text>
               <Column gap="$xs" paddingLeft="$md">
                 <Text color="$textSecondary" size="$3">
                   • You clicked the back button
@@ -59,7 +59,7 @@ export default function CheckoutCancelPage() {
 
           {/* What's Next */}
           <Column gap="$sm" paddingTop="$md" fullWidth>
-            <Text weight="semibold" size="$4">
+            <Text fontWeight="600" size="$4">
               What would you like to do?
             </Text>
             <Column gap="$xs" paddingLeft="$md">

--- a/apps/web/src/app/checkout/page.tsx
+++ b/apps/web/src/app/checkout/page.tsx
@@ -168,7 +168,7 @@ function CheckoutPageContent() {
                       />
                     )}
                     <Column gap="$xs" flex={1}>
-                      <Text size="$5" weight="semibold" numberOfLines={2}>
+                      <Text size="$5" fontWeight="600" numberOfLines={2}>
                         {product.title}
                       </Text>
                       {product.brand && (
@@ -191,7 +191,7 @@ function CheckoutPageContent() {
                     borderTopColor="$border"
                   >
                     <Text color="$textSecondary">Subtotal</Text>
-                    <Text weight="bold" size="$6" color="$primary">
+                    <Text fontWeight="700" size="$6" color="$primary">
                       £{product.price.toFixed(2)}
                     </Text>
                   </Row>

--- a/apps/web/src/app/checkout/success/page.tsx
+++ b/apps/web/src/app/checkout/success/page.tsx
@@ -317,7 +317,7 @@ function CheckoutSuccessContent() {
                 />
               )}
               <Column gap="$xs" flex={1}>
-                <Text weight="bold" size="$5" numberOfLines={2}>
+                <Text fontWeight="700" size="$5" numberOfLines={2}>
                   {order.productTitle}
                 </Text>
                 {order.productBrand && (
@@ -334,7 +334,7 @@ function CheckoutSuccessContent() {
 
           {/* Order Progress Tracker */}
           <Column gap="$md" fullWidth paddingVertical="$md">
-            <Text weight="semibold" size="$5">
+            <Text fontWeight="600" size="$5">
               Order Status
             </Text>
             <Row gap="$sm" alignItems="center" fullWidth>
@@ -375,7 +375,7 @@ function CheckoutSuccessContent() {
                 <Text
                   size="$2"
                   color="$primary"
-                  weight="semibold"
+                  fontWeight="600"
                   textAlign="center"
                   marginTop="$xs"
                 >
@@ -434,14 +434,14 @@ function CheckoutSuccessContent() {
             <Column gap="$md">
               <Row justifyContent="space-between" alignItems="center">
                 <Text color="$textSecondary">Order ID</Text>
-                <Text weight="bold" fontFamily="$body">
+                <Text fontWeight="700" fontFamily="$body">
                   #{order.id.slice(0, 8).toUpperCase()}
                 </Text>
               </Row>
 
               <Row justifyContent="space-between" alignItems="center">
                 <Text color="$textSecondary">Item Price</Text>
-                <Text weight="medium">
+                <Text fontWeight="500">
                   £
                   {(
                     order.amountTotal -
@@ -453,7 +453,7 @@ function CheckoutSuccessContent() {
 
               <Row justifyContent="space-between" alignItems="center">
                 <Text color="$textSecondary">Shipping</Text>
-                <Text weight="medium">£{order.shippingCost.toFixed(2)}</Text>
+                <Text fontWeight="500">£{order.shippingCost.toFixed(2)}</Text>
               </Row>
 
               {order.buyerProtectionFee && order.buyerProtectionFee > 0 && (
@@ -462,7 +462,7 @@ function CheckoutSuccessContent() {
                     <Text color="$textSecondary">Buyer Protection</Text>
                     <ShieldCheck size={14} color="$textSecondary" />
                   </Row>
-                  <Text weight="medium">£{order.buyerProtectionFee.toFixed(2)}</Text>
+                  <Text fontWeight="500">£{order.buyerProtectionFee.toFixed(2)}</Text>
                 </Row>
               )}
 
@@ -473,10 +473,10 @@ function CheckoutSuccessContent() {
                 borderTopWidth={1}
                 borderTopColor="$border"
               >
-                <Text weight="bold" size="$5">
+                <Text fontWeight="700" size="$5">
                   Total Paid
                 </Text>
-                <Text weight="bold" size="$7" color="$primary">
+                <Text fontWeight="700" size="$7" color="$primary">
                   £{order.amountTotal.toFixed(2)}
                 </Text>
               </Row>
@@ -490,7 +490,7 @@ function CheckoutSuccessContent() {
                 borderTopColor="$border"
               >
                 <Text color="$textSecondary">Est. Delivery</Text>
-                <Text weight="semibold" color="$success">
+                <Text fontWeight="600" color="$success">
                   {new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toLocaleDateString("en-GB", {
                     weekday: "short",
                     month: "short",
@@ -548,7 +548,7 @@ function CheckoutSuccessContent() {
             <Column gap="$sm">
               <Row gap="$sm" alignItems="center">
                 <MapPin size={18} color="$text" />
-                <Text weight="semibold">Shipping To</Text>
+                <Text fontWeight="600">Shipping To</Text>
               </Row>
               <Text color="$textSecondary">{order.shippingAddress.name}</Text>
               <Text color="$textSecondary">

--- a/apps/web/src/app/listings/ListingsClient.tsx
+++ b/apps/web/src/app/listings/ListingsClient.tsx
@@ -382,7 +382,7 @@ export function ListingsClient({
           {/* Header */}
           <Row alignItems="center" justifyContent="space-between" flexWrap="wrap" gap="$md">
             <Column gap="$xs">
-              <Text size="$7" $gtMd={{ size: "$9" }} weight="bold">
+              <Text size="$7" $gtMd={{ size: "$9" }} fontWeight="700">
                 Shop All Products
               </Text>
               <Text color="$textSecondary">

--- a/apps/web/src/app/listings/_components/FilterSection.tsx
+++ b/apps/web/src/app/listings/_components/FilterSection.tsx
@@ -25,7 +25,7 @@ export function FilterSection({
         cursor="pointer"
         onPress={() => setIsExpanded(!isExpanded)}
       >
-        <Text weight="semibold" size="$3">
+        <Text fontWeight="600" size="$3">
           {title}
         </Text>
         <Text color="$textSecondary" size="$3">

--- a/apps/web/src/app/listings/_components/FilterSidebar.tsx
+++ b/apps/web/src/app/listings/_components/FilterSidebar.tsx
@@ -46,7 +46,7 @@ export function FilterSidebar({
       display="none"
       $gtLg={{ display: "flex" }}
     >
-      <Text weight="bold" size="$6">
+      <Text fontWeight="700" size="$6">
         Filters
       </Text>
 

--- a/apps/web/src/app/listings/_components/MobileFilterSheet.tsx
+++ b/apps/web/src/app/listings/_components/MobileFilterSheet.tsx
@@ -52,7 +52,7 @@ export function MobileFilterSheet({
           borderBottomColor="$fieldBorder"
         >
           <Row alignItems="center" justifyContent="space-between">
-            <Text id={headingId} weight="bold" size="$6">
+            <Text id={headingId} fontWeight="700" size="$6">
               Filters
             </Text>
             <Text color="$primary" size="$3" cursor="pointer" onPress={onClearAll}>

--- a/apps/web/src/app/listings/_components/ProductsGrid.tsx
+++ b/apps/web/src/app/listings/_components/ProductsGrid.tsx
@@ -124,7 +124,7 @@ export function ProductsGrid({
   if (!isLoading && !isPaginating && products.length === 0) {
     return (
       <Column alignItems="center" justifyContent="center" paddingVertical="$10" gap="$md">
-        <Text size="$7" weight="semibold" color="$textSecondary">
+        <Text size="$7" fontWeight="600" color="$textSecondary">
           No products found
         </Text>
         <Text color="$text">Try adjusting your filters or search query</Text>

--- a/apps/web/src/app/messages/_components/EmptyConversation.tsx
+++ b/apps/web/src/app/messages/_components/EmptyConversation.tsx
@@ -26,7 +26,7 @@ export function EmptyConversation() {
       >
         <MessageSquare size={36} color="$textTertiary" />
       </Column>
-      <Text size="$6" weight="medium" color="$textSecondary">
+      <Text size="$6" fontWeight="500" color="$textSecondary">
         Select a conversation
       </Text>
       <Text size="$4" color="$textTertiary" textAlign="center" maxWidth={280}>

--- a/apps/web/src/app/messages/_components/ListingDetailsPanel.tsx
+++ b/apps/web/src/app/messages/_components/ListingDetailsPanel.tsx
@@ -166,7 +166,7 @@ export function ListingDetailsPanel({
       >
         <Column padding="$lg" gap="$lg" minHeight="100%">
           <Row alignItems="center" justifyContent="space-between">
-            <Text id="listing-details-panel-title" size="$6" weight="bold" color="$text">
+            <Text id="listing-details-panel-title" size="$6" fontWeight="700" color="$text">
               Listing Details
             </Text>
             <Button chromeless size="$3" onPress={onClose}>
@@ -201,7 +201,7 @@ export function ListingDetailsPanel({
             )}
 
             <Column gap="$xs">
-              <Text size="$6" weight="bold" color="$text">
+              <Text size="$6" fontWeight="700" color="$text">
                 {productTitle}
               </Text>
               <Text size="$3" color="$textSecondary">
@@ -210,7 +210,7 @@ export function ListingDetailsPanel({
             </Column>
 
             <Row alignItems="center" justifyContent="space-between">
-              <Text size="$7" weight="bold" color="$primary">
+              <Text size="$7" fontWeight="700" color="$primary">
                 {formattedPrice}
               </Text>
               {productSold ? (
@@ -240,7 +240,7 @@ export function ListingDetailsPanel({
               }}
             >
               <Row alignItems="center" gap="$xs">
-                <Text color="$textInverse" weight="semibold">
+                <Text color="$textInverse" fontWeight="600">
                   Open Listing
                 </Text>
                 <ExternalLink size={14} color="$textInverse" />

--- a/apps/web/src/app/messages/_components/SellerQuickProfilePopover.tsx
+++ b/apps/web/src/app/messages/_components/SellerQuickProfilePopover.tsx
@@ -124,17 +124,17 @@ export function SellerQuickProfilePopover({
                 justifyContent="center"
                 backgroundColor="$backgroundHover"
               >
-                <Text size="$4" weight="bold" color="$textSecondary">
+                <Text size="$4" fontWeight="700" color="$textSecondary">
                   {getInitials(sellerName)}
                 </Text>
               </Column>
             )}
 
             <Column flex={1} gap="$xs">
-              <Text size="$5" weight="semibold" color="$text" numberOfLines={1}>
+              <Text size="$5" fontWeight="600" color="$text" numberOfLines={1}>
                 {sellerName}
               </Text>
-              <Text size="$2" color="$textSecondary" textTransform="uppercase" weight="semibold">
+              <Text size="$2" color="$textSecondary" textTransform="uppercase" fontWeight="600">
                 {userRole === "buyer" ? "Seller" : "Buyer"}
               </Text>
             </Column>
@@ -143,7 +143,7 @@ export function SellerQuickProfilePopover({
           {userRole === "buyer" ? (
             <Row alignItems="center" gap="$xs">
               <Star size={14} color="$warning" />
-              <Text size="$3" weight="semibold" color="$text">
+              <Text size="$3" fontWeight="600" color="$text">
                 {formatRating(averageRating)}
               </Text>
               {safeRatingCount > 0 && (

--- a/apps/web/src/app/messages/_components/ThreadList.tsx
+++ b/apps/web/src/app/messages/_components/ThreadList.tsx
@@ -108,7 +108,7 @@ export function ThreadList({
           <Link href="/listings" style={{ textDecoration: "none" }}>
             <Text
               color="$primary"
-              weight="semibold"
+              fontWeight="600"
               hoverStyle={{ textDecorationLine: "underline" }}
             >
               Browse listings →
@@ -248,7 +248,7 @@ function ConversationRow({
               >
                 <Text
                   size="$5"
-                  weight="semibold"
+                  fontWeight="600"
                   color={isActive ? "$textInverse" : "$textSecondary"}
                 >
                   {getInitials(conversation.otherUserName)}
@@ -263,7 +263,7 @@ function ConversationRow({
         <Row alignItems="center" gap="$xs">
           <Text
             size="$5"
-            weight={hasUnread ? "bold" : "medium"}
+            fontWeight={hasUnread ? "700" : "500"}
             color="$text"
             numberOfLines={1}
             flex={1}
@@ -305,7 +305,7 @@ function ConversationRow({
           </Button>
 
           {conversationStatus && (
-            <Text size="$2" color={conversationStatus.color} weight="semibold" flexShrink={0}>
+            <Text size="$2" color={conversationStatus.color} fontWeight="600" flexShrink={0}>
               {conversationStatus.label}
             </Text>
           )}
@@ -315,7 +315,7 @@ function ConversationRow({
           <Text
             size="$4"
             color={hasUnread ? "$text" : "$textSecondary"}
-            weight={hasUnread ? "semibold" : "normal"}
+            fontWeight={hasUnread ? "600" : "400"}
             numberOfLines={1}
             flex={1}
           >
@@ -333,7 +333,7 @@ function ConversationRow({
                 justifyContent="center"
                 paddingHorizontal="$xs"
               >
-                <Text size="$1" color="$textInverse" weight="bold">
+                <Text size="$1" color="$textInverse" fontWeight="700">
                   {conversation.unreadCount > 9 ? "9+" : conversation.unreadCount}
                 </Text>
               </View>

--- a/apps/web/src/app/products/[id]/_components/ProductInformation.tsx
+++ b/apps/web/src/app/products/[id]/_components/ProductInformation.tsx
@@ -116,7 +116,7 @@ export function ProductInformation({ product, onBuyNow, onSubmitOffer }: Product
       <Column gap="$sm">
         <Row justifyContent="space-between" alignItems="center">
           <Column gap="$xs" flex={1}>
-            <Text size="$3" color="$textSecondary" weight="bold">
+            <Text size="$3" color="$textSecondary" fontWeight="700">
               Posted by {`${product.user.firstName} ${product.user.lastName}`.trim() || "Unknown"}
             </Text>
             <Text size="$2" color="$textSecondary">
@@ -127,7 +127,7 @@ export function ProductInformation({ product, onBuyNow, onSubmitOffer }: Product
                 <Text size="$3" color="$primary">
                   ★
                 </Text>
-                <Text size="$3" color="$text" weight="semibold">
+                <Text size="$3" color="$text" fontWeight="600">
                   {averageRating.toFixed(1)}
                 </Text>
                 <Text size="$2" color="$textSecondary">
@@ -148,16 +148,16 @@ export function ProductInformation({ product, onBuyNow, onSubmitOffer }: Product
       {/* Product Specifications */}
       <Row gap="$md">
         <Column gap="$sm" flex={1}>
-          <Text size="$3" color="$text" weight="bold" lineHeight="$3">
+          <Text size="$3" color="$text" fontWeight="700" lineHeight="$3">
             Category
           </Text>
-          <Text size="$3" color="$text" weight="bold" lineHeight="$3">
+          <Text size="$3" color="$text" fontWeight="700" lineHeight="$3">
             Brand
           </Text>
-          <Text size="$3" color="$text" weight="bold" lineHeight="$3">
+          <Text size="$3" color="$text" fontWeight="700" lineHeight="$3">
             Model
           </Text>
-          <Text size="$3" color="$text" weight="bold" lineHeight="$3">
+          <Text size="$3" color="$text" fontWeight="700" lineHeight="$3">
             Condition
           </Text>
         </Column>
@@ -182,7 +182,7 @@ export function ProductInformation({ product, onBuyNow, onSubmitOffer }: Product
 
       {/* Product Description */}
       <Column gap="$md">
-        <Text size="$3" color="$text" weight="bold">
+        <Text size="$3" color="$text" fontWeight="700">
           Product Description
         </Text>
         <Text size="$3" color="$text">

--- a/apps/web/src/app/sell/_components/SellFormClient.tsx
+++ b/apps/web/src/app/sell/_components/SellFormClient.tsx
@@ -129,7 +129,7 @@ const CONDITION_LABELS: Record<number, string> = {
 // Label component for form fields
 const FormLabel = ({ children, required }: { children: React.ReactNode; required?: boolean }) => (
   <Row gap="$xs" marginBottom="$xs">
-    <Text size="$3" weight="medium" color="$text">
+    <Text size="$3" fontWeight="500" color="$text">
       {children}
     </Text>
     {required && <Text color="$error">*</Text>}
@@ -989,10 +989,10 @@ export function SellFormClient({ draftId }: SellFormClientProps) {
                     {/* Grip Condition */}
                     <Column gap="$xs" width="100%">
                       <Row justifyContent="space-between" alignItems="center">
-                        <Text size="$4" weight="medium" color="$text">
+                        <Text size="$4" fontWeight="500" color="$text">
                           Grip
                         </Text>
-                        <Text size="$4" color="$primary" weight="semibold">
+                        <Text size="$4" color="$primary" fontWeight="600">
                           {formData.gripCondition} - {getConditionLabel(formData.gripCondition)}
                         </Text>
                       </Row>
@@ -1015,10 +1015,10 @@ export function SellFormClient({ draftId }: SellFormClientProps) {
                     {/* Head Condition */}
                     <Column gap="$xs" width="100%">
                       <Row justifyContent="space-between" alignItems="center">
-                        <Text size="$4" weight="medium" color="$text">
+                        <Text size="$4" fontWeight="500" color="$text">
                           Head
                         </Text>
-                        <Text size="$4" color="$primary" weight="semibold">
+                        <Text size="$4" color="$primary" fontWeight="600">
                           {formData.headCondition} - {getConditionLabel(formData.headCondition)}
                         </Text>
                       </Row>
@@ -1041,10 +1041,10 @@ export function SellFormClient({ draftId }: SellFormClientProps) {
                     {/* Shaft Condition */}
                     <Column gap="$xs" width="100%">
                       <Row justifyContent="space-between" alignItems="center">
-                        <Text size="$4" weight="medium" color="$text">
+                        <Text size="$4" fontWeight="500" color="$text">
                           Shaft
                         </Text>
-                        <Text size="$4" color="$primary" weight="semibold">
+                        <Text size="$4" color="$primary" fontWeight="600">
                           {formData.shaftCondition} - {getConditionLabel(formData.shaftCondition)}
                         </Text>
                       </Row>
@@ -1198,7 +1198,7 @@ export function SellFormClient({ draftId }: SellFormClientProps) {
                   <Column gap="$xs" width="100%">
                     <FormLabel required>Price</FormLabel>
                     <Row gap="$sm" alignItems="center">
-                      <Text size="$6" weight="semibold">
+                      <Text size="$6" fontWeight="600">
                         £
                       </Text>
                       <Input

--- a/apps/web/src/components/ImageUpload.tsx
+++ b/apps/web/src/components/ImageUpload.tsx
@@ -334,7 +334,7 @@ export function ImageUpload({
                 <Text size="$12">+</Text>
               </Column>
               <Column gap="$xs" alignItems="center">
-                <Text size="$6" weight="semibold" textAlign="center" color="$text">
+                <Text size="$6" fontWeight="600" textAlign="center" color="$text">
                   Upload photos
                 </Text>
                 <Text size="$3" color="$textSecondary" textAlign="center" lineHeight={20}>
@@ -362,7 +362,7 @@ export function ImageUpload({
                 <Text size="$7">+</Text>
               </Column>
               <Column gap="$xs">
-                <Text size="$4" weight="semibold" color="$text">
+                <Text size="$4" fontWeight="600" color="$text">
                   Add more photos
                 </Text>
                 <Text size="$2" color="$primary">

--- a/apps/web/src/components/TrackingTimeline.tsx
+++ b/apps/web/src/components/TrackingTimeline.tsx
@@ -90,7 +90,7 @@ export function TrackingTimeline({ order, events }: TrackingTimelineProps) {
             <Text size="$3" color="$textSecondary">
               Tracking Number
             </Text>
-            <Text size="$5" weight="semibold" color="$text">
+            <Text size="$5" fontWeight="600" color="$text">
               {trackingCode || "Not available"}
             </Text>
           </Column>
@@ -107,7 +107,7 @@ export function TrackingTimeline({ order, events }: TrackingTimelineProps) {
             <CheckCircle size={16} color="$success" />
             <Text size="$4" color="$textSecondary">
               Est. Delivery:{" "}
-              <Text weight="semibold" color="$text">
+              <Text fontWeight="600" color="$text">
                 {formatDate(estimatedDelivery.toString())}
               </Text>
             </Text>
@@ -146,7 +146,7 @@ export function TrackingTimeline({ order, events }: TrackingTimelineProps) {
               <Column gap="$xs" flex={1}>
                 <Text
                   size="$5"
-                  weight={isCompleted ? "semibold" : "normal"}
+                  fontWeight={isCompleted ? "600" : "400"}
                   color={isCompleted ? "$text" : "$textSecondary"}
                 >
                   {stage.label}
@@ -165,7 +165,7 @@ export function TrackingTimeline({ order, events }: TrackingTimelineProps) {
       {/* Detailed Events */}
       {events.length > 0 && (
         <Column gap="$md" marginTop="$lg">
-          <Text size="$6" weight="semibold" color="$text">
+          <Text size="$6" fontWeight="600" color="$text">
             Tracking History
           </Text>
 
@@ -180,7 +180,7 @@ export function TrackingTimeline({ order, events }: TrackingTimelineProps) {
                 borderLeftWidth={3}
                 borderLeftColor="$primary"
               >
-                <Text size="$4" weight="semibold" color="$text">
+                <Text size="$4" fontWeight="600" color="$text">
                   {event.description}
                 </Text>
 

--- a/packages/app/src/components/HeroSection.tsx
+++ b/packages/app/src/components/HeroSection.tsx
@@ -15,10 +15,10 @@ export function HeroSection() {
       borderBottomColor="$border"
     >
       <Column alignItems="center" gap="$sm" maxWidth={800}>
-        <Heading level={1} size="$10" align="center" fontWeight="700">
+        <Heading level={1} size="$10" textAlign="center" fontWeight="700">
           Ready to declutter your golf bag?
         </Heading>
-        <Heading level={3} size="$6" align="center" color="$textSecondary" fontWeight="400">
+        <Heading level={3} size="$6" textAlign="center" color="$textSecondary" fontWeight="400">
           Buy and sell pre-owned golf equipment with ease
         </Heading>
       </Column>

--- a/packages/app/src/features/messages/message-thread-screen.tsx
+++ b/packages/app/src/features/messages/message-thread-screen.tsx
@@ -707,7 +707,7 @@ export function MessageThreadScreen({
                 />
 
                 <Column gap="$2" width={240}>
-                  <Text size="$5" weight="semibold" color="$text" numberOfLines={1}>
+                  <Text size="$5" fontWeight="600" color="$text" numberOfLines={1}>
                     {otherUserName}
                   </Text>
                   {userRole === "buyer" ? (
@@ -817,7 +817,7 @@ export function MessageThreadScreen({
               <Text
                 size="$3"
                 color="$error"
-                weight="semibold"
+                fontWeight="600"
                 cursor="pointer"
                 onPress={handleRetry}
               >
@@ -827,7 +827,7 @@ export function MessageThreadScreen({
               <Text
                 size="$3"
                 color="$error"
-                weight="semibold"
+                fontWeight="600"
                 cursor="pointer"
                 onPress={() => setError(null)}
               >

--- a/packages/app/src/features/onboarding/screen.tsx
+++ b/packages/app/src/features/onboarding/screen.tsx
@@ -197,10 +197,10 @@ export function OnboardingScreen({
 
         {/* Tagline */}
         <YStack gap={4} alignItems="center">
-          <Text size="$10" fontWeight="500" align="center" color={textColor} lineHeight={32}>
+          <Text size="$10" fontWeight="500" textAlign="center" color={textColor} lineHeight={32}>
             The Marketplace to
           </Text>
-          <Text size="$10" fontWeight="500" align="center" color={textColor} lineHeight={32}>
+          <Text size="$10" fontWeight="500" textAlign="center" color={textColor} lineHeight={32}>
             Buy, Sell & Upgrade
           </Text>
         </YStack>

--- a/packages/eslint-config/react-internal.js
+++ b/packages/eslint-config/react-internal.js
@@ -142,18 +142,13 @@ export const config = [
           paths: reactImportPaths,
         },
       ],
-      // Spacing convention: the NAMED scale ($xs/$sm/$md/$lg/$xl/$2xl/$3xl) is
-      // canonical for padding/margin/gap. Numeric space tokens ($1-$20) remain
-      // valid Tamagui but are being migrated out — warn to steer new code.
-      "no-restricted-syntax": [
-        "warn",
-        {
-          selector:
-            'JSXAttribute[name.name=/^(padding|paddingHorizontal|paddingVertical|paddingTop|paddingBottom|paddingLeft|paddingRight|margin|marginHorizontal|marginVertical|marginTop|marginBottom|marginLeft|marginRight|gap|rowGap|columnGap)$/] > Literal[value=/^\\$\\d/]',
-          message:
-            'Use the named spacing scale ($xs/$sm/$md/$lg/$xl/$2xl/$3xl) instead of numeric space tokens ($1-$20) for padding/margin/gap. The two scales don\'t align; named is canonical.',
-        },
-      ],
+      // Spacing convention: the NAMED scale ($xs-$3xl) is canonical for
+      // padding/margin/gap; numeric space tokens ($1-$20) are legacy and
+      // migrated opportunistically. Not lint-enforced: ESLint flat config
+      // REPLACES no-restricted-syntax per-rule rather than merging, so adding
+      // a selector here would clobber the British-spelling and PrismaClient
+      // selectors from base.js. Revisit as a dedicated plugin rule if drift
+      // continues. Convention documented in .claude/CLAUDE.md.
     },
   },
 ];

--- a/packages/eslint-config/react-internal.js
+++ b/packages/eslint-config/react-internal.js
@@ -142,6 +142,18 @@ export const config = [
           paths: reactImportPaths,
         },
       ],
+      // Spacing convention: the NAMED scale ($xs/$sm/$md/$lg/$xl/$2xl/$3xl) is
+      // canonical for padding/margin/gap. Numeric space tokens ($1-$20) remain
+      // valid Tamagui but are being migrated out — warn to steer new code.
+      "no-restricted-syntax": [
+        "warn",
+        {
+          selector:
+            'JSXAttribute[name.name=/^(padding|paddingHorizontal|paddingVertical|paddingTop|paddingBottom|paddingLeft|paddingRight|margin|marginHorizontal|marginVertical|marginTop|marginBottom|marginLeft|marginRight|gap|rowGap|columnGap)$/] > Literal[value=/^\\$\\d/]',
+          message:
+            'Use the named spacing scale ($xs/$sm/$md/$lg/$xl/$2xl/$3xl) instead of numeric space tokens ($1-$20) for padding/margin/gap. The two scales don\'t align; named is canonical.',
+        },
+      ],
     },
   },
 ];

--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -37,6 +37,9 @@ export default [
         },
       ],
       // Allow raw <input> in Checkbox since it's a hidden form integration element
+      // The named-spacing warn rule targets app code; the DS layer itself uses
+      // numeric space tokens deliberately (aligned with component size tokens).
+      "no-restricted-syntax": "off",
       "react/forbid-elements": [
         "warn",
         {

--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -37,9 +37,6 @@ export default [
         },
       ],
       // Allow raw <input> in Checkbox since it's a hidden form integration element
-      // The named-spacing warn rule targets app code; the DS layer itself uses
-      // numeric space tokens deliberately (aligned with component size tokens).
-      "no-restricted-syntax": "off",
       "react/forbid-elements": [
         "warn",
         {

--- a/packages/ui/src/components/ConversationListItem.tsx
+++ b/packages/ui/src/components/ConversationListItem.tsx
@@ -202,7 +202,7 @@ export function ConversationListItem({
           <Row justifyContent="space-between" alignItems="center">
             <Text
               size="$5"
-              weight={hasUnread ? "bold" : "semibold"}
+              fontWeight={hasUnread ? "700" : "600"}
               numberOfLines={1}
               flex={1}
               color={hasUnread ? "$text" : "$text"}
@@ -236,7 +236,7 @@ export function ConversationListItem({
             <Text
               size="$4"
               color={hasUnread ? "$text" : "$textSecondary"}
-              weight={hasUnread ? "semibold" : "normal"}
+              fontWeight={hasUnread ? "600" : "400"}
               numberOfLines={1}
               flex={1}
             >
@@ -247,7 +247,7 @@ export function ConversationListItem({
             )}
             {hasUnread && !latestOfferStatus && (
               <UnreadDot>
-                <Text size="$1" color="$textInverse" weight="bold">
+                <Text size="$1" color="$textInverse" fontWeight="700">
                   {unreadCount > 9 ? "9+" : unreadCount}
                 </Text>
               </UnreadDot>

--- a/packages/ui/src/components/ErrorBoundary.tsx
+++ b/packages/ui/src/components/ErrorBoundary.tsx
@@ -103,11 +103,11 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
           gap="$lg"
         >
           <Column alignItems="center" gap="$md" maxWidth={400}>
-            <Heading level={2} align="center" color="$error">
+            <Heading level={2} textAlign="center" color="$error">
               Something went wrong
             </Heading>
 
-            <Text align="center" color="$textSecondary">
+            <Text textAlign="center" color="$textSecondary">
               We&apos;re sorry for the inconvenience. The error has been logged and we&apos;ll look
               into it.
             </Text>
@@ -121,7 +121,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
                 width="100%"
                 gap="$sm"
               >
-                <Text weight="semibold" color="$error" size="$3">
+                <Text fontWeight="600" color="$error" size="$3">
                   Error: {this.state.error.message}
                 </Text>
                 {this.state.errorInfo && (

--- a/packages/ui/src/components/OfferCard.tsx
+++ b/packages/ui/src/components/OfferCard.tsx
@@ -132,14 +132,14 @@ export function OfferCard({
           {/* Label row */}
           <Row alignItems="center" gap="$xs">
             {getStatusIcon(type)}
-            <Text size="$3" color="$textSecondary" weight="medium">
+            <Text size="$3" color="$textSecondary" fontWeight="500">
               {getOfferLabel(type, isOwnMessage)}
             </Text>
           </Row>
 
           {/* Amount */}
           {offerAmount != null && (
-            <Text size="$8" weight="bold" color={statusColor}>
+            <Text size="$8" fontWeight="700" color={statusColor}>
               £{offerAmount.toFixed(2)}
             </Text>
           )}

--- a/packages/ui/src/components/Text.tsx
+++ b/packages/ui/src/components/Text.tsx
@@ -64,46 +64,9 @@ export const Text = styled(TamaguiParagraph, {
   // The size prop (e.g., size="$5") automatically applies the correct lineHeight from tokens
   // This fixes text overlap issues caused by unitless multipliers overriding token values
 
-  variants: {
-    weight: {
-      normal: {
-        fontWeight: "400",
-      },
-      medium: {
-        fontWeight: "500",
-      },
-      semibold: {
-        fontWeight: "600",
-      },
-      bold: {
-        fontWeight: "700",
-      },
-    },
-
-    align: {
-      left: {
-        textAlign: "left",
-      },
-      center: {
-        textAlign: "center",
-      },
-      right: {
-        textAlign: "right",
-      },
-    },
-
-    truncate: {
-      true: {
-        overflow: "hidden",
-        textOverflow: "ellipsis",
-        whiteSpace: "nowrap",
-      },
-    },
-  } as const,
-
-  defaultVariants: {
-    weight: "normal",
-  },
+  // No custom weight/align variants — use the native fontWeight/textAlign
+  // props directly (the variants duplicated them and lost 3:1 in practice).
+  fontWeight: "400",
 });
 
 /**
@@ -150,18 +113,6 @@ export const Heading = styled(TamaguiParagraph, {
       6: {
         tag: "h6",
         fontSize: "$5", // 20px heading
-      },
-    },
-
-    align: {
-      left: {
-        textAlign: "left",
-      },
-      center: {
-        textAlign: "center",
-      },
-      right: {
-        textAlign: "right",
       },
     },
   } as const,


### PR DESCRIPTION
Fifth audit PR. **Stacked on #551** — retargets to main automatically as the stack merges; review the last commit until then.

## Problem

Audit found custom Text variants losing to the native props they duplicate:

| DS variant | uses | native prop | uses |
|---|---|---|---|
| `weight="…"` | 114 | `fontWeight=` | 380 |
| `align="…"` | 9 | `textAlign=` | 154 |

Both valid on every `<Text>` — a style decision with two correct answers, sometimes mixed within one file. Same disease as the dual spacing scales (1,001 named vs 840 numeric, 52 files mixing).

## Changes

1. **Variants deleted**: `weight`/`align` from `Text`, `align` from `Heading`, unused `truncate`. Base `Text` keeps explicit `fontWeight: "400"` (was the variant default — zero visual change).
2. **All consumers migrated** mechanically (`weight="bold"` → `fontWeight="700"`, ternaries included), across apps and `packages/ui` internals. `Card.Footer align="right"` intentionally untouched — that's Card's own justifyContent variant, not a Text duplicate.
3. **Spacing convention documented, not lint-enforced**: an earlier revision added a warn-level `no-restricted-syntax` rule; Copilot review found the regex matched the named `$2xl`/`$3xl` tokens and that ESLint flat config REPLACES `no-restricted-syntax` per-rule (clobbering the British-spelling and PrismaClient selectors from base.js). Rule removed in the same branch; the named-scale convention is now stated in CLAUDE.md, with an explanatory comment left in react-internal.js. Revisit as a dedicated plugin rule if numeric-token drift continues.

## Test plan

- `pnpm check` green — type-check proves no `weight=`/`align=` stragglers anywhere (deleting the variant makes remaining uses type errors)
- Grep: zero non-Card `align="` / bare `weight="` remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)
