### PR TITLE
fix(web): collapse duplicated Product/model spec row

### DIFF
--- a/apps/web/src/app/products/[id]/_components/ProductInformation.tsx
+++ b/apps/web/src/app/products/[id]/_components/ProductInformation.tsx
@@ -155,10 +155,7 @@ export function ProductInformation({ product, onBuyNow, onSubmitOffer }: Product
             Brand
           </Text>
           <Text size="$3" color="$text" weight="bold" lineHeight="$3">
-            Product
-          </Text>
-          <Text size="$3" color="$text" weight="bold" lineHeight="$3">
-            Product
+            Model
           </Text>
           <Text size="$3" color="$text" weight="bold" lineHeight="$3">
             Condition
@@ -170,9 +167,6 @@ export function ProductInformation({ product, onBuyNow, onSubmitOffer }: Product
           </Text>
           <Text size="$3" color="$text" lineHeight="$3">
             {product.brand || "N/A"}
-          </Text>
-          <Text size="$3" color="$text" lineHeight="$3">
-            {product.model || "N/A"}
           </Text>
           <Text size="$3" color="$text" lineHeight="$3">
             {product.model || "N/A"}


### PR DESCRIPTION
Product detail page rendered the specifications row twice: two "Product" labels, two `{product.model || "N/A"}` values. Collapsed to a single row labelled "Model".

Pre-existing bug spotted by Copilot on [#552](https://github.com/kyln-digital/buttergolf/pull/552); out of scope there. Note: will produce a trivial 2-line merge conflict with #552 (same lines get `weight=` → `fontWeight=` there) — whichever merges second resolves.

- `pnpm check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)