### PR TITLE
chore(web): re-enable TypeScript checking in next build

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -58,12 +58,6 @@ const securityHeaders = [
 module.exports = () => {
   /** @type {import('next').NextConfig} */
   let config = {
-    typescript: {
-      // !! WARN !!
-      // Temporarily disable type checking during build due to React 19 + Tamagui compatibility issues
-      // This should be resolved when Tamagui updates its types for React 19
-      ignoreBuildErrors: true,
-    },
     // Explicitly trace Prisma binaries from custom monorepo location
     // Required for Vercel deployment with custom Prisma output path
     // Paths are relative to outputFileTracingRoot (monorepo root)


### PR DESCRIPTION
Continuation of #553 (auto-closed when its stacked base branch was deleted on #548's merge — branch since rebased onto main, identical single commit).

`typescript.ignoreBuildErrors: true` was justified by "React 19 + Tamagui compatibility issues". Those are gone: `tsc --noEmit` passes clean in every workspace. The flag was hiding real problems — the `brandColors` undefined-import crash fixed in #548 would have been caught at build time with this off.

Self-review verdict from #553 carries over: no issues found; flag was explicitly temporary when added (250c8603); Vercel build with checking enabled is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)