### PR TITLE
chore: post-merge review residuals from Tamagui audit

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,7 @@ This guide also documents our authentication setup using Clerk for both platform
 - **React Native**: 0.81.5
 - **React Native Web**: 0.21.2 (enables React Native components on web)
 - **TypeScript**: 5.9.2 (strict mode)
-- **Styling**: Tailwind CSS v4 (web), Tamagui (cross-platform)
+- **Styling**: Tamagui (cross-platform)
 - **Navigation**: Solito 5.0.0 for unified cross-platform routing
 - **Bundlers**:
   - Metro (mobile) - custom workspace-aware configuration
@@ -1208,13 +1208,9 @@ Each app extends this base configuration.
 </View>
 ```
 
-### Tailwind CSS (Web Only)
+### No Tailwind
 
-Used in Next.js for web-specific styling when Tamagui doesn't fit:
-
-```tsx
-<div className="container mx-auto px-4">{/* Tailwind classes */}</div>
-```
+Tailwind was removed (never emitted CSS — it was installed but never imported). Web-specific styling Tamagui can't express goes in `globals.css` or scoped `<style>` blocks.
 
 ## Build & Compilation
 
@@ -2127,7 +2123,7 @@ Use the Context7 MCP server for up-to-date library documentation. Always call `r
 6. **ALWAYS use layout components** - Use `<Row>`, `<Column>`, `<Container>` instead of raw `<XStack>`/`<YStack>`
 7. **NEVER use numbered colors** - Don't use `$color9`, `$color11`, `$blue10`, etc.
 8. **NEVER use old token names** - Don't use `$borderColor`, `$textDark`, `$bg`, `$color`, etc.
-9. **NEVER mix Tamagui and Tailwind** - Keep Tamagui for components, Tailwind for page layouts only
+9. **NEVER add Tailwind** - Removed from the repo; Tamagui only (globals.css for rare web-only CSS)
 
 ### 🚨 NEVER Use Tamagui Components in Server Components
 
@@ -2204,7 +2200,7 @@ export default async function Layout({ children }) {
 23. **Define variants for common patterns** - If you're writing the same props 3+ times, make it a variant
 24. **Use direct tokens for one-offs** - Don't create variants for rarely-used combinations
 25. **Avoid `style` prop in shared code** - In `packages/ui` and `packages/app`, use Tamagui's native props so the compiler can optimize. In web-only files (`apps/web`), you may use `style` for genuine web-only CSS like `position: sticky` or `overflow: auto`.
-26. **Use Tamagui Text with size tokens** - In shared cross-platform code, use `<Text size="$5">` with numeric tokens (NOT `fontSize`). For web-only custom typography (like CSS clamp), create dedicated components in `apps/web` or use Tailwind classes.
+26. **Use Tamagui Text with size tokens** - In shared cross-platform code, use `<Text size="$5">` with numeric tokens (NOT `fontSize`). For web-only custom typography (like CSS clamp), create dedicated components in `apps/web`.
 
 ### British Spelling Convention
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All internal packages use the `@buttergolf/` namespace and the `workspace:*` pro
 ## Stack
 
 - **Build**: Turborepo + pnpm workspaces
-- **UI**: Tamagui (web + native); Tailwind CSS v4 on web
+- **UI**: Tamagui (web + native)
 - **Navigation**: Next.js App Router (web), React Navigation + Solito (mobile)
 - **Database**: Prisma 6 + PostgreSQL (Neon)
 - **Auth**: Clerk

--- a/apps/mobile/components/MobileCheckoutSheet.tsx
+++ b/apps/mobile/components/MobileCheckoutSheet.tsx
@@ -1,7 +1,6 @@
 import { useState, useCallback, memo } from "react";
-import { Sheet } from "@buttergolf/ui";
 import { InteractionManager } from "react-native";
-import { Column, Row, Text, Button, Heading, Card, Spinner } from "@buttergolf/ui";
+import { Button, Card, Column, Heading, Row, Sheet, Spinner, Text } from "@buttergolf/ui";
 import {
   SHIPPING_OPTIONS,
   calculateBuyerProtectionFeeInPence,

--- a/apps/web/src/app/products/[id]/_components/BuyNowSheet.tsx
+++ b/apps/web/src/app/products/[id]/_components/BuyNowSheet.tsx
@@ -2,8 +2,7 @@
 
 import { useState, useCallback, memo } from "react";
 import { useRouter } from "next/navigation";
-import { Sheet } from "@buttergolf/ui";
-import { Column, Row, Text, Button, Heading, Image } from "@buttergolf/ui";
+import { Button, Column, Heading, Image, Row, Sheet, Text } from "@buttergolf/ui";
 import { Lock, Package, CheckCircle } from "@tamagui/lucide-icons";
 import { StripePaymentForm } from "@/app/checkout/_components/StripePaymentForm";
 import type { Product } from "../ProductDetailClient";

--- a/packages/app/src/features/orders/order-detail-screen.tsx
+++ b/packages/app/src/features/orders/order-detail-screen.tsx
@@ -12,9 +12,9 @@ import {
   ScrollView,
   Badge,
   View,
+  TextArea,
 } from "@buttergolf/ui";
 import { Avatar } from "tamagui";
-import { TextArea } from "@buttergolf/ui";
 import {
   ArrowLeft,
   Package,

--- a/packages/app/src/features/products/OfferSheet.tsx
+++ b/packages/app/src/features/products/OfferSheet.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useCallback } from "react";
-import { Sheet } from "@buttergolf/ui";
-import { Column, Row, Text, Button, Heading, Input } from "@buttergolf/ui";
+import { Button, Column, Heading, Input, Row, Sheet, Text } from "@buttergolf/ui";
 import { Tag } from "@tamagui/lucide-icons";
 
 interface OfferSheetProps {

--- a/packages/config/src/brand-colors.ts
+++ b/packages/config/src/brand-colors.ts
@@ -1,8 +1,8 @@
 // Brand colours - base/hover/press shades per family (status colours add Light/Dark)
 // Brand colours from Figma - Pure Butter Golf Theme (sRGB)
 // Single source of truth: these feed the Tamagui tokens/themes below and are
-// exported for the rare contexts that need raw hex values (React Navigation
-// themes, Stripe appearance objects, WebView inline styles).
+// exported for the rare contexts that need raw colour values (React Navigation
+// themes, Stripe appearance objects, WebView inline styles); includes hex and rgba strings.
 export const brandColors = {
   // Primary - Spiced Clementine (vibrant orange)
   spicedClementine: "#F45314",

--- a/packages/config/src/tamagui.config.ts
+++ b/packages/config/src/tamagui.config.ts
@@ -178,7 +178,7 @@ const bodyFont = createFont({
   face: urbanistFace,
 });
 
-// Brand colours live in ./brand-colors.ts (a dependency-free module). Raw-hex
+// Brand colours live in ./brand-colors.ts (a dependency-free module). Raw-colour
 // consumers should import from "./brand-colors" directly to stay free of
 // tamagui/createTamagui; importing via this module or the package barrel still
 // loads the full config (the web webpack singleton alias forces that anyway).


### PR DESCRIPTION
Copilot review cycles raced the merges of #548-#552 — this sweeps up the residual comments per the follow-up-PR rule.

- **Stale Tailwind claims** removed from `README.md` and `.github/copilot-instructions.md` (stack line, "Tailwind CSS (Web Only)" section, rules 9/26) — Tailwind left the repo in #549.
- **"Raw hex" → raw colour values** in brand-colours comments — the palette includes rgba overlay strings, not just hex.
- **Duplicate `@buttergolf/ui` import lines merged** in the four files where #551's mechanical migration added `Sheet`/`TextArea` as separate imports.

Not done, deliberately: the suggested `@buttergolf/config/brand-colors` subpath export — the web webpack singleton alias (`@buttergolf/config` → package source) resolves the whole package regardless of entry, so a subpath wouldn't change the WebView bundle until that alias becomes exact-match (`$`). Worth doing together if bundle size of `/mobile-onboarding` ever matters; noted, not now.

Also verified already-fixed despite fresh comments: Card.tsx JSDoc (compound form landed in #549's d24cac79 — the review quoted the fixed content).

- `pnpm check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)